### PR TITLE
Disable the PMD analysis cache

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -5,6 +5,10 @@ def _pmd_test_impl(ctx):
         ctx.executable._pmd.short_path,
     ]
 
+    # We want to disable the suggestion to use the analysis cache
+    # https://pmd.github.io/latest/pmd_userdocs_incremental_analysis.html#disabling-incremental-analysis
+    cmd.extend(["-no-cache"])
+
     inputs = []
     transitive_inputs = depset()
 


### PR DESCRIPTION
We never set this in the first place, but users would see a
warning that they could improve build times by using it. Since
each test run is hermetic, we can't realistically do that, so
instead we disable the warning.