### PR TITLE
Allow the checkstyle binary to be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,48 @@ Use spotbugs to lint the `srcs`.
 | <a id="spotbugs_test-only_output_jars"></a>only_output_jars |  If set to true, only the output jar of the target will be analyzed. Otherwise all transitive runtime dependencies will be analyzed   | Boolean | optional | True |
 
 
+<a id="#checkstyle_binary"></a>
+
+## checkstyle_binary
+
+<pre>
+checkstyle_binary(<a href="#checkstyle_binary-name">name</a>, <a href="#checkstyle_binary-main_class">main_class</a>, <a href="#checkstyle_binary-deps">deps</a>, <a href="#checkstyle_binary-runtime_deps">runtime_deps</a>, <a href="#checkstyle_binary-srcs">srcs</a>, <a href="#checkstyle_binary-visibility">visibility</a>, <a href="#checkstyle_binary-kwargs">kwargs</a>)
+</pre>
+
+Macro for quickly generating a `java_binary` target for use with `checkstyle_config`.
+
+By default, this will set the `main_class` to point to the default one used by checkstyle
+but it's ultimately a drop-replacement for straight `java_binary` target.
+
+At least one of `runtime_deps`, `deps`, and `srcs` must be specified so that the
+`java_binary` target will be valid.
+
+An example would be:
+
+```starlark
+checkstyle_binary(
+    name = "checkstyle_cli",
+    runtime_deps = [
+        artifact("com.puppycrawl.tools:checkstyle"),
+    ]
+)
+```
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="checkstyle_binary-name"></a>name |  The name of the target   |  none |
+| <a id="checkstyle_binary-main_class"></a>main_class |  The main class to use for checkstyle.   |  <code>"com.puppycrawl.tools.checkstyle.Main"</code> |
+| <a id="checkstyle_binary-deps"></a>deps |  The deps required for compiling this binary. May be omitted.   |  <code>None</code> |
+| <a id="checkstyle_binary-runtime_deps"></a>runtime_deps |  The deps required by checkstyle at runtime. May be omitted.   |  <code>None</code> |
+| <a id="checkstyle_binary-srcs"></a>srcs |  If you're compiling your own <code>checkstyle</code> binary, the sources to use.   |  <code>None</code> |
+| <a id="checkstyle_binary-visibility"></a>visibility |  <p align="center"> - </p>   |  <code>["//visibility:public"]</code> |
+| <a id="checkstyle_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <a id="#java_binary"></a>
 
 ## java_binary

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ These rules require Java 11 or above.
 ## checkstyle_config
 
 <pre>
-checkstyle_config(<a href="#checkstyle_config-name">name</a>, <a href="#checkstyle_config-config_file">config_file</a>, <a href="#checkstyle_config-output_format">output_format</a>)
+checkstyle_config(<a href="#checkstyle_config-name">name</a>, <a href="#checkstyle_config-checkstyle_binary">checkstyle_binary</a>, <a href="#checkstyle_config-config_file">config_file</a>, <a href="#checkstyle_config-data">data</a>, <a href="#checkstyle_config-output_format">output_format</a>)
 </pre>
 
  Rule allowing checkstyle to be configured. This is typically
@@ -78,7 +78,9 @@ checkstyle_config(<a href="#checkstyle_config-name">name</a>, <a href="#checksty
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="checkstyle_config-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
+| <a id="checkstyle_config-checkstyle_binary"></a>checkstyle_binary |  Checkstyle binary to use.   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @contrib_rules_jvm//java:checkstyle_cli |
 | <a id="checkstyle_config-config_file"></a>config_file |  The config file to use for all checkstyle tests   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
+| <a id="checkstyle_config-data"></a>data |  Additional files to make available to Checkstyle such as any included XML files   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="checkstyle_config-output_format"></a>output_format |  Output format to use. Defaults to plain   | String | optional | "plain" |
 
 
@@ -87,7 +89,7 @@ checkstyle_config(<a href="#checkstyle_config-name">name</a>, <a href="#checksty
 ## checkstyle_test
 
 <pre>
-checkstyle_test(<a href="#checkstyle_test-name">name</a>, <a href="#checkstyle_test-config">config</a>, <a href="#checkstyle_test-configuration_file">configuration_file</a>, <a href="#checkstyle_test-output_format">output_format</a>, <a href="#checkstyle_test-srcs">srcs</a>)
+checkstyle_test(<a href="#checkstyle_test-name">name</a>, <a href="#checkstyle_test-config">config</a>, <a href="#checkstyle_test-output_format">output_format</a>, <a href="#checkstyle_test-srcs">srcs</a>)
 </pre>
 
 Use checkstyle to lint the `srcs`.
@@ -98,8 +100,7 @@ Use checkstyle to lint the `srcs`.
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="checkstyle_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="checkstyle_test-config"></a>config |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
-| <a id="checkstyle_test-configuration_file"></a>configuration_file |  Configuration file. If not specified a default file is used   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |
+| <a id="checkstyle_test-config"></a>config |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @contrib_rules_jvm//java:checkstyle-default-config |
 | <a id="checkstyle_test-output_format"></a>output_format |  Output Format can be plain or xml. Defaults to plain   | String | optional | "plain" |
 | <a id="checkstyle_test-srcs"></a>srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 

--- a/docs/stardoc-input.bzl
+++ b/docs/stardoc-input.bzl
@@ -1,5 +1,6 @@
 load(
     "//java:defs.bzl",
+    _checkstyle_binary = "checkstyle_binary",
     _checkstyle_config = "checkstyle_config",
     _checkstyle_test = "checkstyle_test",
     _java_binary = "java_binary",
@@ -14,6 +15,7 @@ load(
     _spotbugs_test = "spotbugs_test",
 )
 
+checkstyle_binary = _checkstyle_binary
 checkstyle_config = _checkstyle_config
 checkstyle_test = _checkstyle_test
 java_binary = _java_binary

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -28,7 +28,6 @@ checkstyle_config(
 
 java_binary(
     name = "checkstyle_cli",
-    testonly = True,
     main_class = "com.puppycrawl.tools.checkstyle.Main",
     runtime_deps = [
         artifact("com.puppycrawl.tools:checkstyle"),

--- a/java/BUILD.bazel
+++ b/java/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//java/private:artifact.bzl", "artifact")
-load("//java/private:checkstyle_config.bzl", "checkstyle_config")
+load("//java/private:checkstyle_config.bzl", "checkstyle_binary", "checkstyle_config")
 load("//java/private:spotbugs_config.bzl", "spotbugs_config")
 load("//java/private:pmd_ruleset.bzl", "pmd_ruleset")
 
@@ -26,12 +26,11 @@ checkstyle_config(
     config_file = "checkstyle-strict.xml",
 )
 
-java_binary(
+checkstyle_binary(
     name = "checkstyle_cli",
-    main_class = "com.puppycrawl.tools.checkstyle.Main",
     runtime_deps = [
         artifact("com.puppycrawl.tools:checkstyle"),
-    ],
+    ]
 )
 
 java_binary(

--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -1,5 +1,8 @@
 load("//java/private:checkstyle.bzl", _checkstyle_test = "checkstyle_test")
-load("//java/private:checkstyle_config.bzl", _checkstyle_config = "checkstyle_config")
+load(
+    "//java/private:checkstyle_config.bzl",
+    _checkstyle_binary = "checkstyle_binary",
+    _checkstyle_config = "checkstyle_config")
 load("//java/private:java_test_suite.bzl", _java_test_suite = "java_test_suite")
 load(
     "//java/private:junit5.bzl",
@@ -19,6 +22,7 @@ load("//java/private:pmd_ruleset.bzl", _pmd_ruleset = "pmd_ruleset")
 load("//java/private:spotbugs.bzl", _spotbugs_test = "spotbugs_test")
 load("//java/private:spotbugs_config.bzl", _spotbugs_config = "spotbugs_config")
 
+checkstyle_binary = _checkstyle_binary
 checkstyle_config = _checkstyle_config
 checkstyle_test = _checkstyle_test
 java_binary = _java_binary

--- a/java/private/checkstyle_config.bzl
+++ b/java/private/checkstyle_config.bzl
@@ -1,5 +1,6 @@
 CheckStyleInfo = provider(
     fields = {
+        "checkstyle": "The checkstyle binary to use.",
         "config_file": "The config file to use.",
         "output_format": "Output Format can be plain or xml.",
     },
@@ -8,9 +9,11 @@ CheckStyleInfo = provider(
 def _checkstyle_config_impl(ctx):
     return [
         DefaultInfo(
-            runfiles = ctx.runfiles(ctx.files.data + [ctx.file.config_file]),
+            runfiles = ctx.runfiles(ctx.files.data + [ctx.file.config_file]).merge(
+                ctx.attr.checkstyle_binary[DefaultInfo].default_runfiles),
         ),
         CheckStyleInfo(
+            checkstyle = ctx.executable.checkstyle_binary,
             config_file = ctx.file.config_file,
             output_format = ctx.attr.output_format,
         ),
@@ -35,6 +38,15 @@ checkstyle_config = rule(
         "data": attr.label_list(
             doc = "Additional files to make available to Checkstyle such as any included XML files",
             allow_files = True,
+        ),
+        "checkstyle_binary": attr.label(
+            doc = "Checkstyle binary to use.",
+            default = "@contrib_rules_jvm//java:checkstyle_cli",
+            executable = True,
+            cfg = "exec",
+            providers = [
+                JavaInfo,
+            ],
         ),
     },
     provides = [

--- a/java/private/checkstyle_config.bzl
+++ b/java/private/checkstyle_config.bzl
@@ -1,3 +1,50 @@
+
+def checkstyle_binary(
+        name,
+        main_class = "com.puppycrawl.tools.checkstyle.Main",
+        deps = None,
+        runtime_deps = None,
+        srcs = None,
+        visibility = ["//visibility:public"],
+        **kwargs):
+    """Macro for quickly generating a `java_binary` target for use with `checkstyle_config`.
+
+    By default, this will set the `main_class` to point to the default one used by checkstyle
+    but it's ultimately a drop-replacement for straight `java_binary` target.
+
+    At least one of `runtime_deps`, `deps`, and `srcs` must be specified so that the
+    `java_binary` target will be valid.
+
+    An example would be:
+
+    ```starlark
+    checkstyle_binary(
+        name = "checkstyle_cli",
+        runtime_deps = [
+            artifact("com.puppycrawl.tools:checkstyle"),
+        ]
+    )
+    ```
+
+    Args:
+      name: The name of the target
+      main_class: The main class to use for checkstyle.
+      deps: The deps required for compiling this binary. May be omitted.
+      runtime_deps: The deps required by checkstyle at runtime. May be omitted.
+      srcs: If you're compiling your own `checkstyle` binary, the sources to use.
+    """
+
+    native.java_binary(
+        name = name,
+        main_class = main_class,
+        srcs = srcs,
+        deps = deps,
+        runtime_deps = runtime_deps,
+        visibility = visibility,
+        **kwargs
+    )
+
+
 CheckStyleInfo = provider(
     fields = {
         "checkstyle": "The checkstyle binary to use.",


### PR DESCRIPTION
This allows users to select the version of checkstyle that they
want to use without being rail-roaded into taking the version
that ships with `rules_contrib_jvm`.

We also remove the `config_file` option, and instead always make
users specify the `checkstyle_config` that they want to use. This
will likely reduce boilerplate and duplication in people's build
files, and also makes it easier for us to figure out the right
binary to use.

Closes #10