### PR TITLE
Add `ai` to common package prefixes

### DIFF
--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -1,5 +1,5 @@
 # Common package prefixes, in the order we want to check for them
-_PREFIXES = (".com.", ".org.", ".net.", ".io.")
+_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.")
 
 # By default bazel computes the name of test classes based on the
 # standard Maven directory structure, which we may not always use,


### PR DESCRIPTION
Without it, we face;
> java.lang.ClassNotFoundException: src.test.java.ai.my.company.sub.pkg.MyTest

Passing `package = ".ai."` (or `ai.`/`.ai`/`ai`) doesn't help:
> java.lang.ClassNotFoundException: .ai.src.test.java.ai.my.company.sub.pkg.MyTest

I guess adding `ai` here is an acceptable short-term solution given the popularity of this domain name extension.