### PR TITLE
PMD: replace deprecated -filelist with --file-list

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -19,7 +19,7 @@ def _pmd_test_impl(ctx):
         file_list,
         ",".join([src.path for src in ctx.files.srcs]),
     )
-    cmd.extend(["-filelist", file_list.short_path])
+    cmd.extend(["--file-list", file_list.short_path])
     inputs.extend(ctx.files.srcs)
     inputs.append(file_list)
 


### PR DESCRIPTION
This fixes a quite noisy recurring warning:
```
[date and time] net.sourceforge.pmd.PMD runPmd
WARNING: Some deprecated options were used on the command-line, including -filelist
[date and time] net.sourceforge.pmd.PMD runPmd
WARNING: Consider replacing it with --file-list
```