### PR TITLE
PMD: fix other deprecated command line arguments

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -9,7 +9,7 @@ def _pmd_test_impl(ctx):
 
     # We want to disable the suggestion to use the analysis cache
     # https://pmd.github.io/latest/pmd_userdocs_incremental_analysis.html#disabling-incremental-analysis
-    cmd.extend(["-no-cache"])
+    cmd.extend(["--no-cache"])
 
     inputs = []
     transitive_inputs = depset()
@@ -32,7 +32,7 @@ def _pmd_test_impl(ctx):
         jars = ctx.attr.target[JavaInfo].transitive_runtime_jars.to_list()
         if len(jars) > 0:
             aux_class_path = ctx.host_configuration.host_path_separator.join([jar.short_path for jar in jars])
-            cmd.extend(["-auxclasspath", aux_class_path])
+            cmd.extend(["--aux-classpath", aux_class_path])
 
             # runfiles requires the depset to be in `default` order
             transitive_inputs = depset(


### PR DESCRIPTION
Commit eac2e95d3e19a3562ace0a741b561a620c5a833e (#15) addressed the deprecation of `-filelist` by `--file-list`, but didn't consider other affected command line arguments.

The present change aims at paying that debt:
- `-auxclasspath` by `--aux-classpath`,
- `-no-cache` by `--no-cache`.

Short form arguments (`-R`, `-f`) are _not_ affected.

See https://pmd.github.io/2021/11/27/PMD-6.41.0/