### PR TITLE
Narrow filtering of imports in modules

### DIFF
--- a/java/gazelle/testdata/module-granularity/module1/BUILD.want
+++ b/java/gazelle/testdata/module-granularity/module1/BUILD.want
@@ -7,7 +7,10 @@ java_library(
         "src/main/java/com/example/hello/Hello.java",
         "src/main/java/com/example/hello/world/World.java",
     ],
-    _gazelle_imports = ["java.lang.String"],
+    _gazelle_imports = [
+        "com.example.hello.notworld.NotWorld",
+        "java.lang.String",
+    ],
     _java_packages = [
         "com.example.hello",
         "com.example.hello.world",

--- a/java/gazelle/testdata/module-granularity/module1/src/main/java/com/example/hello/Hello.java
+++ b/java/gazelle/testdata/module-granularity/module1/src/main/java/com/example/hello/Hello.java
@@ -1,10 +1,12 @@
 package com.example.hello;
 
 import com.example.hello.world.World;
+import com.example.hello.notworld.NotWorld;
 
 public class Hello {
     public static void main(String[] args) {
         World one = new World();
         System.out.printf("Hello, %s!", one.name);
+        System.out.printf("Hello also, %s!", NotWorld.NOT_WORLD);
     }
 }

--- a/java/gazelle/testdata/module-granularity/notmodule/src/main/java/com/example/hello/notworld/NotWorld.java
+++ b/java/gazelle/testdata/module-granularity/notmodule/src/main/java/com/example/hello/notworld/NotWorld.java
@@ -1,0 +1,5 @@
+package com.example.hello.notworld;
+
+public class NotWorld {
+  public static final String NOT_WORLD = "Not World!";
+}


### PR DESCRIPTION
This ensures that when you have:

module/com/example/Foo
otherpackage/com/example/not_in_module/Bar

module's dependency on Bar isn't filtered out.