### PR TITLE
Add two missing archive dependencies used by external system which 

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -77,3 +77,12 @@ bzl_library(
         "@contrib_rules_jvm_deps//:defs",
     ],
 )
+
+bzl_library(
+    name = "gazelle_setup",
+    srcs = ["gazelle_setup.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/go:repositories",
+    ],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -3,44 +3,17 @@ workspace(name = "contrib_rules_jvm")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "apple_rules_lint",
-    sha256 = "8feab4b08a958b10cb2abb7f516652cd770b582b36af6477884b3bba1f2f0726",
-    strip_prefix = "apple_rules_lint-0.1.1",
-    url = "https://github.com/apple/apple_rules_lint/archive/0.1.1.zip",
-)
-
-http_archive(
-    name = "bazel_gazelle",
-    sha256 = "cb1f888a5363f89945ece2254576bd84730aac2642d64ee1bbcfb500735a8beb",
-    strip_prefix = "bazel-gazelle-2190265f2fabd2383765fdfbed158106ebe81e9b",
-    url = "https://github.com/bazelbuild/bazel-gazelle/archive/2190265f2fabd2383765fdfbed158106ebe81e9b.tar.gz",
-)
-
-http_archive(
-    name = "io_bazel_rules_go",
-    sha256 = "2b1641428dff9018f9e85c0384f03ec6c10660d935b750e3fa1492a281a53b0f",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/v0.29.0/rules_go-v0.29.0.zip",
-)
-
-http_archive(
-    name = "io_bazel_stardoc",
-    sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
-    url = "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
-)
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
-    strip_prefix = "rules_proto-4.0.0",
-    url = "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
-)
-
-http_archive(
     name = "rules_python",
     sha256 = "cdf6b84084aad8f10bf20b46b77cb48d83c319ebe6458a18e9d2cebf57807cdd",
     strip_prefix = "rules_python-0.8.1",
     url = "https://github.com/bazelbuild/rules_python/archive/refs/tags/0.8.1.tar.gz",
 )
+
+load("//:repositories.bzl", "contrib_rules_jvm_deps", "contrib_rules_jvm_gazelle_deps")
+
+contrib_rules_jvm_deps()
+
+contrib_rules_jvm_gazelle_deps()
 
 load("@apple_rules_lint//lint:repositories.bzl", "lint_deps")
 
@@ -54,14 +27,14 @@ lint_setup({
     "java-spotbugs": "//java:spotbugs-default-config",
 })
 
-load("//:repositories.bzl", "contrib_rules_jvm_deps")
-
-contrib_rules_jvm_deps()
-
 load("//:setup.bzl", "contrib_rules_jvm_setup")
 
 # gazelle:repository_macro third_party/go/repositories.bzl%go_deps
 contrib_rules_jvm_setup()
+
+load("//:gazelle_setup.bzl", "contib_rules_jvm_gazelle_setup")
+
+contib_rules_jvm_gazelle_setup()
 
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_grpc_grpc_java//:repositories.bzl", "IO_GRPC_GRPC_JAVA_ARTIFACTS")

--- a/gazelle_setup.bzl
+++ b/gazelle_setup.bzl
@@ -1,0 +1,6 @@
+load("@io_grpc_grpc_java//:repositories.bzl", "io_grpc_grpc_proto")
+load("//third_party/go:repositories.bzl", "go_deps")
+
+def contib_rules_jvm_gazelle_setup():
+    io_grpc_grpc_proto()
+    go_deps()

--- a/java/gazelle/README.md
+++ b/java/gazelle/README.md
@@ -4,8 +4,24 @@ This provides an experimental [Gazelle][] extension to generate build files for
 Java projects.
 
 ## Usage
+In the `WORKSPACE` file set up the rules_jvm correctly:
+```starlark
+load("@contrib_rules_jvm//:repositories.bzl", "contrib_rules_jvm_deps", "contrib_rules_jvm_gazelle_deps")
 
-In the top level BUILD file, setup Gazelle to use gazelle-languages binary:
+contrib_rules_jvm_deps()
+
+contrib_rules_jvm_gazelle_deps()
+
+load("@contrib_rules_jvm//:setup.bzl", "contrib_rules_jvm_setup")
+
+contrib_rules_jvm_setup()
+
+load("@contrib_rules_jvm//:gazelle_setup.bzl", "contib_rules_jvm_gazelle_setup")
+
+contib_rules_jvm_gazelle_setup()
+```
+
+In the top level `BUILD.bazel` file, setup Gazelle to use gazelle-languages binary:
 
 ```starlark
 load("@bazel_gazelle//:def.bzl", "DEFAULT_LANGUAGES", "gazelle", "gazelle_binary")

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -10,6 +10,12 @@ def contrib_rules_jvm_deps():
         strip_prefix = "apple_rules_lint-0.1.1",
         url = "https://github.com/apple/apple_rules_lint/archive/0.1.1.zip",
     )
+    maybe(
+        http_archive,
+        name = "io_bazel_stardoc",
+        sha256 = "c9794dcc8026a30ff67cf7cf91ebe245ca294b20b071845d12c192afe243ad72",
+        url = "https://github.com/bazelbuild/stardoc/releases/download/0.5.0/stardoc-0.5.0.tar.gz",
+    )
 
     maybe(
         http_archive,
@@ -51,4 +57,32 @@ def contrib_rules_jvm_deps():
             "@contrib_rules_jvm//java/private:make-docs-visible.patch",
         ],
         patch_args = ["-p1"],
+    )
+
+def contrib_rules_jvm_gazelle_deps():
+    maybe(
+        http_archive,
+        name = "bazel_gazelle",
+        sha256 = "dae13a7c6adb742174aafd340ebcb36016de231bd4f926f79c140c7d9b599fb0",
+        strip_prefix = "bazel-gazelle-757e291d1befe9174fb1fcf0d9ade733cbb6b904",
+        urls = [
+            "https://github.com/bazelbuild/bazel-gazelle/archive/757e291d1befe9174fb1fcf0d9ade733cbb6b904.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "io_bazel_rules_go",
+        sha256 = "f2dcd210c7095febe54b804bb1cd3a58fe8435a909db2ec04e31542631cf715c",
+        urls = [
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.31.0/rules_go-v0.31.0.zip",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_proto",
+        sha256 = "66bfdf8782796239d3875d37e7de19b1d94301e8972b3cbd2446b332429b4df1",
+        strip_prefix = "rules_proto-4.0.0",
+        url = "https://github.com/bazelbuild/rules_proto/archive/refs/tags/4.0.0.tar.gz",
     )

--- a/setup.bzl
+++ b/setup.bzl
@@ -1,12 +1,8 @@
 load("@apple_rules_lint//lint:setup.bzl", "ruleset_lint_setup")
 load("@contrib_rules_jvm_deps//:compat.bzl", "compat_repositories")
 load("@contrib_rules_jvm_deps//:defs.bzl", "pinned_maven_install")
-load("@io_grpc_grpc_java//:repositories.bzl", "io_grpc_grpc_proto")
-load("//third_party/go:repositories.bzl", "go_deps")
 
 def contrib_rules_jvm_setup():
     ruleset_lint_setup()
     pinned_maven_install()
     compat_repositories()
-    io_grpc_grpc_proto()
-    go_deps()


### PR DESCRIPTION
are pulled in implicitly. But if used externally, this causes build failures when they are not included correctly.

Move some of the Gazelle dependencies and setup to separate files/packages

To avoid loading the enormous Go toolchain if not really using the Gazelle setup.