### PR TITLE
Use getQualifiedName

### DIFF
--- a/java/gazelle/testdata/annotations/src/main/java/com/example/BUILD.want
+++ b/java/gazelle/testdata/annotations/src/main/java/com/example/BUILD.want
@@ -1,0 +1,9 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "example",
+    srcs = ["Main.java"],
+    _gazelle_imports = ["java.beans.Transient"],
+    _java_packages = ["com.example"],
+    visibility = ["//:__subpackages__"],
+)

--- a/java/gazelle/testdata/annotations/src/main/java/com/example/Main.java
+++ b/java/gazelle/testdata/annotations/src/main/java/com/example/Main.java
@@ -1,0 +1,9 @@
+package com.example;
+
+import java.beans.Transient;
+
+public class Main {
+    public boolean isNonNull(Transient field) {
+        return field != null;
+    }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -127,12 +127,12 @@ public class ClasspathParser {
                         .asReferenceType()
                         .getTypeDeclaration()
                         .get();
-                typeName = type.getPackageName() + "." + type.getClassName();
+                typeName = type.getQualifiedName();
               } else {
                 try {
                   ResolvedReferenceType ref = coit.resolve();
                   type = ref.getTypeDeclaration().get();
-                  typeName = type.getPackageName() + "." + type.getClassName();
+                  typeName = type.getQualifiedName();
                 } catch (UnsolvedSymbolException exception) {
                   logger.trace(
                       "Working on class {} And unable to find: {} -" + " Continuing",

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/PackageDependencies.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/PackageDependencies.java
@@ -160,7 +160,7 @@ public class PackageDependencies {
                         .asReferenceType()
                         .getTypeDeclaration()
                         .get();
-                typeName = type.getPackageName() + "." + type.getClassName();
+                typeName = type.getQualifiedName();
               } else {
                 try {
                   ref = coit.resolve();
@@ -194,7 +194,7 @@ public class PackageDependencies {
               }
               if (ref != null) {
                 type = ref.getTypeDeclaration().get();
-                typeName = type.getPackageName() + "." + type.getClassName();
+                typeName = type.getQualifiedName();
               }
               if (typeName != null) {
                 JavaIdentifier source = typeSolver.resolveSourceForType(typeName);


### PR DESCRIPTION
There's a bug in javaparser where annotation class names looked up by
reflective detection have an additional . added to them which causes a
crash.

While we wait for the fix to be PR'd/merged/released upstream, use the
upstream method for getting a fully qualified name, rather than
splitting and joining.

Fixes https://github.com/bazel-contrib/rules_jvm/pull/35