### PR TITLE
Only visit each ClassOrInterfaceType once

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -18,6 +18,7 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -108,10 +109,15 @@ public class ClasspathParser {
   }
 
   private void parseClasses(CompilationUnit cu) {
+    Set<ClassOrInterfaceType> visited = new HashSet<>();
+
     // CLASSES : Checking the fully qualified class or interface names
     cu.findAll(ClassOrInterfaceType.class)
         .forEach(
             coit -> {
+              if (visited.contains(coit)) {
+                return;
+              }
               ResolvedReferenceTypeDeclaration type;
               String typeName = null;
               if (!Character.isUpperCase(coit.getName().asString().charAt(0))) {
@@ -165,6 +171,7 @@ public class ClasspathParser {
               if (typeName != null) {
                 usedTypes.add(typeName);
               }
+              visited.add(coit);
             });
   }
 


### PR DESCRIPTION
For large repetitive classes, e.g. generated protobuf or avro files
which have a great many methods which interact with the same handful of
types, repeatedly processing the same types over and over again is very
expensive.

For instance, this drops the time taken to process
https://github.com/harness/harness-core/blob/develop/280-batch-processing/src/generated/java/io/harness/avro/ClusterBillingData.java
which is generated code containing a great many references to just 16
types down from 24 seconds to 4 seconds.

4 seconds is still a lot; we should probably do some parallelisation
here, but 4 seconds is a lot better than 24 seconds (particularly when
we currently have a hard cut-off of 30 seconds before we give up and
crash). We may also want to memoize these across classes, and even
calls.