### PR TITLE
gazelle: Add javax.xml as provided by JDK

### DIFF
--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -40,6 +40,7 @@ var stdlibPrefixes = []string{
 	"javax.naming.",
 	"javax.net.",
 	"javax.security.",
+	"javax.xml.",
 	"jdk.",
 	"sun.",
 }


### PR DESCRIPTION
This resolve the gazelle issue in this repository from junit5/BazelJUnitOutputListener.java:

```
missing import javax.xml.stream.XMLOutputFactory pkg=javax.xml.stream targets=[]
```