### PR TITLE
gazelle: Fix a resolve issue with gRPC

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -31,6 +31,7 @@ buildifier(
 # gazelle:resolve java com.google.common.collect @contrib_rules_jvm_deps//:com_google_guava_guava
 # gazelle:resolve java com.google.gson @contrib_rules_jvm_deps//:com_google_code_gson_gson
 # gazelle:resolve java io.grpc @contrib_rules_jvm_deps//:io_grpc_grpc_api
+# gazelle:resolve java io.grpc.protobuf.services @contrib_rules_jvm_deps//:io_grpc_grpc_services
 # gazelle:resolve java io.grpc.stub @contrib_rules_jvm_deps//:io_grpc_grpc_stub
 # gazelle:resolve java javax.annotation @contrib_rules_jvm_deps//:com_google_code_findbugs_jsr305
 # gazelle:resolve java org.apache.commons.cli @contrib_rules_jvm_deps//:commons_cli_commons_cli


### PR DESCRIPTION
This fixes an issue where gazelle would misuse `@maven` repository:

```diff
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -26,9 +26,9 @@ java_library(
         "@contrib_rules_jvm_deps//:com_google_guava_guava",
         "@contrib_rules_jvm_deps//:commons_cli_commons_cli",
         "@contrib_rules_jvm_deps//:io_grpc_grpc_api",
-        "@contrib_rules_jvm_deps//:io_grpc_grpc_services",
         "@contrib_rules_jvm_deps//:io_grpc_grpc_stub",
         "@contrib_rules_jvm_deps//:org_slf4j_slf4j_api",
+        "@maven//:io_grpc_grpc_services",
     ],
 )
```