### PR TITLE
gazelle: Fix deps ordering when using #keep

### DIFF
--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -3,7 +3,6 @@ package gazelle
 import (
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/java"
 	"github.com/bazelbuild/bazel-gazelle/config"
@@ -142,7 +141,7 @@ func (jr Resolver) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.Rem
 
 		var exprs []build.Expr
 		for _, l := range labels {
-			exprs = append(exprs, &build.LiteralExpr{Token: strconv.Quote(l.String())})
+			exprs = append(exprs, &build.StringExpr{Value: l.String()})
 		}
 		r.SetAttr("deps", exprs)
 	}

--- a/java/gazelle/resolve_test.go
+++ b/java/gazelle/resolve_test.go
@@ -109,6 +109,14 @@ java_library(
 			ix.Finish()
 			for i, r := range f.Rules {
 				mrslv.Resolver(r, "").Resolve(c, ix, rc, r, imports[i], label.New("", tc.old.rel, r.Name()))
+
+				if r.Attr("deps") != nil {
+					for _, dep := range r.Attr("deps").(*bzl.ListExpr).List {
+						if _, ok := dep.(*bzl.StringExpr); !ok {
+							t.Errorf("rule %s deps deps should have type []StringExpr", r.Name())
+						}
+					}
+				}
 			}
 			f.Sync()
 			got := strings.TrimSpace(string(bzl.Format(f.File)))


### PR DESCRIPTION
Fixes an ordering issue with using `#keep` comments in deps attribute.

The [mergeList](https://github.com/bazelbuild/bazel-gazelle/blob/a98769c9a26e312ac40d1f5b14f574fdcd4aa21a/rule/merge.go#L144) function expects both arguments to be lists of the same kind of `build.Expr`. The `dst` "deps" attribute is parsed as a list of `build.StringExpr`.