### PR TITLE
Allow setting visibility for java_test_suite libraries

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -81,6 +81,7 @@ def create_jvm_test_suite(
             deps = deps,
             srcs = nontest_srcs,
             testonly = True,
+            visibility = visibility,
             **library_attrs
         )
         deps.append(":%s-test-lib" % name)


### PR DESCRIPTION
Currently, there is no way for other packages to depend on the
implicitly generated test library. This allows for a BUILD file author
to opt in to making the generated test library more visible.

This re-uses the visibility attribute which is also currently used for
the visibility of the generated `test_suite`. This feels less fiddly
than introducing a separate attribute.