### PR TITLE
Bump io_grpc_grpc_java dep

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -90,9 +90,9 @@ def contrib_rules_jvm_gazelle_deps():
     maybe(
         http_archive,
         name = "io_grpc_grpc_java",
-        sha256 = "e3781bcab2a410a7cd138f13b2e6a643e111575f6811b154c570f4d020e87507",
-        strip_prefix = "grpc-java-1.44.0",
-        urls = ["https://github.com/grpc/grpc-java/archive/v1.44.0.tar.gz"],
+        sha256 = "0f6cf8c1e97757333e08975c8637093b40540a54a201cfd3ce284c8d1d073fae",
+        strip_prefix = "grpc-java-1.47.0",
+        urls = ["https://github.com/grpc/grpc-java/archive/v1.47.0.tar.gz"],
     )
 
     maybe(


### PR DESCRIPTION
Recent protobuf appears to have introduced a change which breaks this
version, removing `google/protobuf/compiler/java/java_names.h`.

Also, we're already using 1.47.0 in `contrib_rules_jvm_deps`, so this is
consistent across the file.