### PR TITLE
Fix up helper library generation

### DIFF
--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/BUILD.want
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/BUILD.want
@@ -2,7 +2,10 @@ load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 java_library(
     name = "modulewithhelpers",
-    srcs = [], # TODO: There should definitely be some srcs in here.
+    srcs = [
+        "Helper.java",
+        "withdirectory/Helper.java",
+    ],
     _gazelle_imports = [],
     _java_packages = [
         "com.example.modulewithhelpers",

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/somemodule/BUILD.want
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/somemodule/BUILD.want
@@ -1,13 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library", "java_test")
-
-# TODO: With no srcs, this probably shouldn't get output.
-java_library(
-    name = "somemodule",
-    srcs = [],
-    _gazelle_imports = [],
-    _java_packages = ["com.example.somemodule.withdirectory"],
-    visibility = ["//:__subpackages__"],
-)
+load("@rules_java//java:defs.bzl", "java_test")
 
 java_test(
     name = "com_example_somemodule_withdirectory_ATest",

--- a/java/gazelle/testdata/module-granularity/testmodule/src/test/java/com/example/hello/notworld/withhelpers/BUILD.want
+++ b/java/gazelle/testdata/module-granularity/testmodule/src/test/java/com/example/hello/notworld/withhelpers/BUILD.want
@@ -1,17 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library") # TODO: This load shouldn't get generated, because there shouldn't be a java_library here
 load("@contrib_rules_jvm//java:defs.bzl", "java_test_suite")
-
-# TODO: This library _shouldn't_ get generated in suite mode
-java_library(
-    name = "withhelpers",
-    srcs = [],
-    _gazelle_imports = [],
-    _java_packages = [
-        "com.example.hello.notworld.withhelpers",
-        "com.example.hello.notworld.withhelpers.withdirectory",
-    ],
-    visibility = ["//:__subpackages__"],
-)
 
 java_test_suite(
     name = "withhelpers-tests",


### PR DESCRIPTION
Where libraries are generated, they should have sources. Where they have
no sources, they shouldn't be generated. And where we're generating a
suite, which itself generates a helper library, we shouldn't generate
one at all.