### PR TITLE
Fix up helper file deps

### DIFF
--- a/java/gazelle/generate_test.go
+++ b/java/gazelle/generate_test.go
@@ -17,40 +17,34 @@ func TestSingleJavaTestFile(t *testing.T) {
 		imports     []string
 		wantImports []string
 
-		testHelperFiles []string
-		wantDeps        []string
+		wantDeps []string
 	}
 
 	for name, tc := range map[string]testCase{
 		"no imports no helpers": {
-			imports:         nil,
-			wantImports:     []string{"com.example"},
-			testHelperFiles: nil,
-			wantDeps:        nil,
+			imports:     nil,
+			wantImports: []string{"com.example"},
+			wantDeps:    nil,
 		},
 		"some imports no helpers": {
-			imports:         []string{"io.netty"},
-			wantImports:     []string{"io.netty", "com.example"},
-			testHelperFiles: nil,
-			wantDeps:        nil,
+			imports:     []string{"io.netty"},
+			wantImports: []string{"io.netty", "com.example"},
+			wantDeps:    nil,
 		},
 		"no imports some helpers": {
-			imports:         nil,
-			wantImports:     []string{"com.example"},
-			testHelperFiles: []string{"Helper.java"},
-			wantDeps:        []string{"Helper.java"},
+			imports:     nil,
+			wantImports: []string{"com.example"},
+			wantDeps:    []string{":helper"},
 		},
 		"some imports some helpers": {
-			imports:         []string{"io.netty"},
-			wantImports:     []string{"io.netty", "com.example"},
-			testHelperFiles: []string{"Helper.java"},
-			wantDeps:        []string{"Helper.java"},
+			imports:     []string{"io.netty"},
+			wantImports: []string{"io.netty", "com.example"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			var res language.GenerateResult
 
-			makeSingleJavaTest(f, tc.testHelperFiles, sorted_set.NewSortedSet(tc.imports), &res)
+			makeSingleJavaTest(f, sorted_set.NewSortedSet([]string{}), sorted_set.NewSortedSet(tc.imports), &res)
 
 			require.Len(t, res.Gen, 1, "want 1 generated rule")
 
@@ -59,12 +53,8 @@ func TestSingleJavaTestFile(t *testing.T) {
 			require.Equal(t, "FooTest", rule.AttrString("name"))
 			require.Equal(t, []string{"FooTest.java"}, rule.AttrStrings("srcs"))
 			require.Equal(t, "com.example.FooTest", rule.AttrString("test_class"))
-			require.Equal(t, tc.wantDeps, rule.AttrStrings("deps"))
 
 			wantAttrs := []string{"name", "srcs", "test_class"}
-			if len(tc.wantDeps) > 0 {
-				wantAttrs = append(wantAttrs, "deps")
-			}
 			require.ElementsMatch(t, wantAttrs, rule.AttrKeys())
 
 			require.Len(t, res.Imports, 1, "want 1 generated imports")

--- a/java/gazelle/private/sorted_set/btreeset.go
+++ b/java/gazelle/private/sorted_set/btreeset.go
@@ -85,3 +85,7 @@ func (s *SortedSet[T]) Clone() *SortedSet[T] {
 		tree: s.tree.Clone(),
 	}
 }
+
+func (s *SortedSet[T]) Len() int {
+	return s.tree.Len()
+}

--- a/java/gazelle/private/sorted_set/btreeset_test.go
+++ b/java/gazelle/private/sorted_set/btreeset_test.go
@@ -46,6 +46,10 @@ func TestInsert(t *testing.T) {
 	s := ss.NewSortedSet([]string{})
 
 	{
+		if len := s.Len(); len != 0 {
+			t.Errorf("Want len 0 got %v", len)
+		}
+
 		got := s.SortedSlice()
 		want := []string{}
 		if !reflect.DeepEqual(got, want) {
@@ -62,6 +66,10 @@ func TestInsert(t *testing.T) {
 
 	s.Add("cheese")
 	{
+		if len := s.Len(); len != 1 {
+			t.Errorf("Want len 1 got %v", len)
+		}
+
 		got := s.SortedSlice()
 		want := []string{"cheese"}
 		if !reflect.DeepEqual(got, want) {
@@ -78,6 +86,10 @@ func TestInsert(t *testing.T) {
 
 	s.Add("cheese")
 	{
+		if len := s.Len(); len != 1 {
+			t.Errorf("Want len 1 got %v", len)
+		}
+
 		got := s.SortedSlice()
 		want := []string{"cheese"}
 		if !reflect.DeepEqual(got, want) {
@@ -94,6 +106,10 @@ func TestInsert(t *testing.T) {
 
 	s.Add("onions")
 	{
+		if len := s.Len(); len != 2 {
+			t.Errorf("Want len 2 got %v", len)
+		}
+
 		got := s.SortedSlice()
 		want := []string{"cheese", "onions"}
 		if !reflect.DeepEqual(got, want) {
@@ -110,6 +126,10 @@ func TestInsert(t *testing.T) {
 
 	s.Add("brie")
 	{
+		if len := s.Len(); len != 3 {
+			t.Errorf("Want len 3 got %v", len)
+		}
+
 		got := s.SortedSlice()
 		want := []string{"brie", "cheese", "onions"}
 		if !reflect.DeepEqual(got, want) {

--- a/java/gazelle/testdata/java_test_per_file/BUILD.bazel.in
+++ b/java/gazelle/testdata/java_test_per_file/BUILD.bazel.in
@@ -1,1 +1,3 @@
 # gazelle:java_test_mode file
+
+# gazelle:resolve java org.hamcrest @maven//:org_hamcrest_hamcrest_all

--- a/java/gazelle/testdata/java_test_per_file/WORKSPACE
+++ b/java/gazelle/testdata/java_test_per_file/WORKSPACE
@@ -13,7 +13,7 @@ maven_install(
     artifacts = [
         "com.google.guava:guava:30.0-jre",
         "junit:junit:4.13.1",
-        "org.hamcrest:hamcrest-core:1.3",
+        "org.hamcrest:hamcrest-all:1.3",
     ],
     fetch_sources = True,
     repositories = [

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/AppTest.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/AppTest.java
@@ -2,6 +2,8 @@ package com.example.hashelpers;
 
 import static org.junit.Assert.assertEquals;
 
+import com.example.myproject.App;
+
 import org.junit.Test;
 
 public class AppTest {

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/BUILD.want
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/BUILD.want
@@ -1,11 +1,28 @@
-load("@rules_java//java:defs.bzl", "java_test")
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
-# TODO: There should be a java_library generated in here.
+java_library(
+    name = "hashelpers",
+    testonly = True,
+    srcs = ["Helper.java"],
+    _gazelle_imports = [
+        "com.example.myproject.App", # TODO: per-file tests should have per-test imports, excluding this one
+        "com.google.common.math.IntMath",
+        "java.lang.Exception", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.hamcrest.MatcherAssert", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.hamcrest.Matchers", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.junit.Assert", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.junit.Test", # TODO: per-file tests should have per-test imports, excluding this one
+    ],
+    _java_packages = ["_TESTONLY!com.example.hashelpers"],
+)
+
 java_test(
     name = "AppTest",
     srcs = ["AppTest.java"],
     _gazelle_imports = [
+        "_TESTONLY!com.example.hashelpers",
         "com.example.hashelpers",
+        "com.example.myproject.App",
         "com.google.common.math.IntMath", # TODO: per-file tests should have per-test imports, excluding this one
         "java.lang.Exception",
         "org.hamcrest.MatcherAssert", # TODO: per-file tests should have per-test imports, excluding this one
@@ -15,17 +32,15 @@ java_test(
     ],
     _java_packages = ["com.example.hashelpers"],
     test_class = "com.example.hashelpers.AppTest",
-    deps = [
-        "AppTest.java",
-        "OtherAppTest.java", # TODO: per-file tests should have per-test imports, excluding this one
-    ],
 )
 
 java_test(
     name = "OtherAppTest",
     srcs = ["OtherAppTest.java"],
     _gazelle_imports = [
+        "_TESTONLY!com.example.hashelpers",
         "com.example.hashelpers",
+        "com.example.myproject.App",
         "com.google.common.math.IntMath", # TODO: per-file tests should have per-test imports, excluding this one
         "java.lang.Exception",
         "org.hamcrest.MatcherAssert",
@@ -35,8 +50,4 @@ java_test(
     ],
     _java_packages = ["com.example.hashelpers"],
     test_class = "com.example.hashelpers.OtherAppTest",
-    deps = [
-        "AppTest.java", # TODO: per-file tests should have per-test imports, excluding this one
-        "OtherAppTest.java",
-    ],
 )

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/Helper.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/Helper.java
@@ -3,7 +3,7 @@ package com.example.hashelpers;
 import com.google.common.math.IntMath;
 
 public class Helper {
-  public int powerOfOne(int x) {
+  public static int powerOfOne(int x) {
     return IntMath.checkedPow(x, 1);
   }
 }

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/OtherAppTest.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/hashelpers/OtherAppTest.java
@@ -3,6 +3,8 @@ package com.example.hashelpers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.example.myproject.App;
+
 import org.junit.Test;
 
 public class OtherAppTest {

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/AppTest.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/AppTest.java
@@ -2,6 +2,8 @@ package com.example.modulewithhelpers;
 
 import static org.junit.Assert.assertEquals;
 
+import com.example.myproject.App;
+
 import org.junit.Test;
 
 public class AppTest {

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/BUILD.want
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/BUILD.want
@@ -6,7 +6,15 @@ java_library(
         "Helper.java",
         "withdirectory/Helper.java",
     ],
-    _gazelle_imports = [],
+    _gazelle_imports = [
+        "com.example.myproject.App", # TODO: per-file tests should have per-test imports, excluding this one
+        "com.google.common.math.IntMath",
+        "java.lang.Exception", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.hamcrest.MatcherAssert", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.hamcrest.Matchers", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.junit.Assert", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.junit.Test", # TODO: per-file tests should have per-test imports, excluding this one
+    ],
     _java_packages = [
         "com.example.modulewithhelpers",
         "com.example.modulewithhelpers.withdirectory",
@@ -22,8 +30,8 @@ java_test(
         "com.example.myproject.App",
         "com.google.common.math.IntMath", # TODO: per-file tests should have per-test imports, excluding this one
         "java.lang.Exception",
-        "org.hamcrest.MatcherAssert",
-        "org.hamcrest.Matchers",
+        "org.hamcrest.MatcherAssert", # TODO: per-file tests should have per-test imports, excluding this one
+        "org.hamcrest.Matchers", # TODO: per-file tests should have per-test imports, excluding this one
         "org.junit.Assert",
         "org.junit.Test",
     ],

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/Helper.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/Helper.java
@@ -3,7 +3,7 @@ package com.example.modulewithhelpers;
 import com.google.common.math.IntMath;
 
 public class Helper {
-  public int powerOfOne(int x) {
+  public static int powerOfOne(int x) {
     return IntMath.checkedPow(x, 1);
   }
 }

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/withdirectory/Helper.java
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/modulewithhelpers/withdirectory/Helper.java
@@ -3,7 +3,7 @@ package com.example.modulewithhelpers.withdirectory;
 import com.google.common.math.IntMath;
 
 public class Helper {
-  public int powerOfOne(int x) {
+  public static int powerOfOne(int x) {
     return IntMath.checkedPow(x, 1);
   }
 }

--- a/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/myproject/BUILD.want
+++ b/java/gazelle/testdata/java_test_per_file/src/test/java/com/example/myproject/BUILD.want
@@ -13,10 +13,6 @@ java_test(
     ],
     _java_packages = ["com.example.myproject"],
     test_class = "com.example.myproject.AppTest",
-    deps = [
-        "AppTest.java",
-        "OtherAppTest.java", # TODO: per-file tests should not have deps on other files (or maybe even themselves?)
-    ],
 )
 
 java_test(
@@ -32,8 +28,4 @@ java_test(
     ],
     _java_packages = ["com.example.myproject"],
     test_class = "com.example.myproject.OtherAppTest",
-    deps = [
-        "AppTest.java", # TODO: per-file tests should not have deps on other files (or maybe even themselves?)
-        "OtherAppTest.java",
-    ],
 )

--- a/java/gazelle/testdata/module-granularity/module1/BUILD.want
+++ b/java/gazelle/testdata/module-granularity/module1/BUILD.want
@@ -10,6 +10,10 @@ java_library(
     _gazelle_imports = [
         "com.example.hello.notworld.NotWorld",
         "java.lang.String",
+        "org.hamcrest.MatcherAssert",
+        "org.hamcrest.Matchers",
+        "org.junit.Assert",
+        "org.junit.jupiter.api.Test",
     ],
     _java_packages = [
         "com.example.hello",


### PR DESCRIPTION
This now adds deps on actual targets, via the resolver, and also ensures
that the helper library is always generated where it should be.

There's a significant question here for module-mode, as to whether we
should be generating one `java_library` for all of the code, or a
test-specific `java_library` and a production `java_library. Currently,
this code generates a single shared one, as generating separate ones
would require non-trivial rework of how imports are resolved.