### PR TITLE
Split proto generation into a separate java package

### DIFF
--- a/java/gazelle/testdata/grpc/src/main/java/com/example/hello/BUILD.want
+++ b/java/gazelle/testdata/grpc/src/main/java/com/example/hello/BUILD.want
@@ -4,8 +4,8 @@ java_library(
     name = "hello",
     srcs = ["hello.java"],
     _gazelle_imports = [
-        "com.example.hello.DeleteBookRequest",
-        "com.example.hello.HelloProto",
+        "com.example.hello.proto.DeleteBookRequest",
+        "com.example.hello.proto.HelloProto",
         "java.lang.String",
     ],
     _java_packages = ["com.example.hello"],

--- a/java/gazelle/testdata/grpc/src/main/java/com/example/hello/hello.java
+++ b/java/gazelle/testdata/grpc/src/main/java/com/example/hello/hello.java
@@ -1,7 +1,7 @@
 package com.example.hello;
 
-import com.example.hello.DeleteBookRequest;
-import com.example.hello.HelloProto;
+import com.example.hello.proto.DeleteBookRequest;
+import com.example.hello.proto.HelloProto;
 
 public class Hello {
     public static void main(String[] args) {

--- a/java/gazelle/testdata/grpc/src/main/proto/example/hello/BUILD.want
+++ b/java/gazelle/testdata/grpc/src/main/proto/example/hello/BUILD.want
@@ -25,7 +25,7 @@ java_grpc_library(
 java_library(
     name = "example_hello_java_library",
     _gazelle_imports = [],
-    _java_packages = ["com.example.hello"],
+    _java_packages = ["com.example.hello.proto"],
     visibility = ["//:__subpackages__"],
     exports = [
         ":example_hello_java_grpc",

--- a/java/gazelle/testdata/grpc/src/main/proto/example/hello/hello.proto
+++ b/java/gazelle/testdata/grpc/src/main/proto/example/hello/hello.proto
@@ -4,7 +4,7 @@ package example.hello;
 
 import "google/protobuf/empty.proto";
 
-option java_package = "com.example.hello";
+option java_package = "com.example.hello.proto";
 option java_multiple_files = true;
 option java_outer_classname = "HelloProto";
 


### PR DESCRIPTION
We currently perform package-level not class-level resolution, so the
existing test data would actually fail when hitting the resolver because
we wouldn't be able to identify the proto as the source of this package.

Instead, use a unique package name (as we'd currently recommend users
do). We may change this expectation in the future, but for now, this is
a constraint of the system.