### PR TITLE
Also detect JUnit Pioneer imports imply JUnit 5

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -453,11 +453,19 @@ func importsJunit4(imports *sorted_set.SortedSet[string]) bool {
 	return imports.Contains("org.junit.Test") || imports.Contains("org.junit")
 }
 
+// Determines whether the given import is part of the JUnit Pioneer extension pack for JUnit 5. Only the beginning of
+// the string is considered here to cover classes imported from different sub-packages: org.junitpioneer.vintage.Test,
+// org.junitpioneer.jupiter.RetryingTest, org.junitpioneer.jupiter.cartesian.CartesianTest, etc.
+func importsJunitPioneer(import_ string) bool {
+	return strings.HasPrefix(import_, "org.junitpioneer.")
+}
+
 func importsJunit5(imports *sorted_set.SortedSet[string]) bool {
 	return imports.Contains("org.junit.jupiter.api.Test") ||
 		imports.Contains("org.junit.jupiter.api") ||
 		imports.Contains("org.junit.jupiter.params.ParameterizedTest") ||
-		imports.Contains("org.junit.jupiter.params")
+		imports.Contains("org.junit.jupiter.params") ||
+		imports.Filter(importsJunitPioneer).Len() != 0
 }
 
 var junit5RuntimeDeps = []string{

--- a/java/gazelle/generate_test.go
+++ b/java/gazelle/generate_test.go
@@ -106,6 +106,17 @@ func TestSingleJavaTestFile(t *testing.T) {
 				"@maven//:org_junit_platform_junit_platform_reporting",
 			},
 		},
+		"junitpioneer junit5": {
+			includePackageInName: false,
+			imports:              []string{"org.junitpioneer.jupiter.cartesian.CartesianTest"},
+			wantRuleKind:         "java_junit5_test",
+			wantImports:          []string{"com.example", "org.junitpioneer.jupiter.cartesian.CartesianTest"},
+			wantRuntimeDeps: []string{
+				"@maven//:org_junit_jupiter_junit_jupiter_engine",
+				"@maven//:org_junit_platform_junit_platform_launcher",
+				"@maven//:org_junit_platform_junit_platform_reporting",
+			},
+		},
 		"explicit both junit4 and junit5": {
 			includePackageInName: false,
 			imports:              []string{"org.junit.Test", "org.junit.jupiter.api.Test"},


### PR DESCRIPTION
In the same way that #80 brought detection of test classes that only use `@ParameterizedTest` to determine they're also JUnit 5-dependent, the change proposed here aims at extending it to test annotations provided by [JUnit Pioneer](https://junit-pioneer.org/) (Eclipse Public License v2.0).

As its classes are organized under various [sub-packages](https://javadoc.io/doc/org.junit-pioneer/junit-pioneer/latest/index.html), only the prefix of the imports is considered here.

Suggestion: perhaps we could consider a good old regex to combine all these predicates into one.