### PR TITLE
Avoid Java 17 printing a warning about the SecurityManager

### DIFF
--- a/java/private/junit5.bzl
+++ b/java/private/junit5.bzl
@@ -47,12 +47,22 @@ def java_junit5_test(name, test_class = None, runtime_deps = [], **kwargs):
     else:
         clazz = get_package_name() + name
 
+    jvm_flags = kwargs.pop("jvm_flags", [])
+    for f in jvm_flags:
+        if f.startswith("-Djava.security.manager="):
+            fail("Only the JUnit5 runner is allowed to set the security manager via a JVM flag")
+
     java_test(
         name = name,
         main_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.JUnit5Runner",
         test_class = clazz,
         runtime_deps = runtime_deps + [
             "@contrib_rules_jvm//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
+        ],
+        jvm_flags = jvm_flags + [
+            # In later versions of Java (after version 11, at least), we could set the value "allow"
+            # but earlier releases need a class name.
+            "-Djava.security.manager=com.github.bazel_contrib.contrib_rules_jvm.junit5.TestRunningSecurityManager",
         ],
         **kwargs
     )

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -50,18 +50,13 @@ public class ActualRunner implements RunsTest {
       String filter = System.getenv("TESTBRIDGE_TEST_ONLY");
       request.filters(new PatternFilter(filter));
 
-      File exitFile = getExitFile();
       var originalSecurityManager = System.getSecurityManager();
-      TestRunningSecurityManager testSecurityManager =
-          new TestRunningSecurityManager(originalSecurityManager);
-      try {
-        System.setSecurityManager(testSecurityManager);
-        var launcher = LauncherFactory.create(config);
-        launcher.execute(request.build());
-      } finally {
-        testSecurityManager.allowRemoval();
-        System.setSecurityManager(originalSecurityManager);
-      }
+
+      File exitFile = getExitFile();
+
+      var launcher = LauncherFactory.create(config);
+      launcher.execute(request.build());
+
       deleteExitFile(exitFile);
 
       try (PrintWriter writer = new PrintWriter(System.out)) {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -18,7 +18,7 @@ public class JUnit5Runner {
 
     if (testSuite == null || testSuite.isBlank()) {
       System.err.println("No test suite specified");
-      System.exit(2); // Same error code as Bazel's own test runner
+      exit(2); // Same error code as Bazel's own test runner
     }
 
     detectJUnit5Classes();
@@ -28,17 +28,17 @@ public class JUnit5Runner {
           Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();
       var runsTest = constructor.newInstance();
       if (!runsTest.run(testSuite)) {
-        System.exit(2);
+        exit(2);
       }
     } catch (ReflectiveOperationException e) {
       e.printStackTrace(System.err);
       System.err.println("Unable to create delegate test runner");
-      System.exit(2);
+      exit(2);
     }
 
     // Exit manually. If we don't do this then tests which hold resources
     // such as Threads may prevent us from exiting properly.
-    System.exit(0);
+    exit(0);
   }
 
   private static void detectJUnit5Classes() {
@@ -64,5 +64,14 @@ public class JUnit5Runner {
               "JUnit 5 test runner is missing a dependency on `artifact(\"%s\")`%n",
               containedInDependency));
     }
+  }
+
+  private static void exit(int value) {
+    var manager = System.getSecurityManager();
+    if (manager instanceof TestRunningSecurityManager) {
+      var trsm = (TestRunningSecurityManager) manager;
+      trsm.allowExitCall();
+    }
+    System.exit(value);
   }
 }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestRunningSecurityManagerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestRunningSecurityManagerTest.java
@@ -11,16 +11,18 @@ public class TestRunningSecurityManagerTest {
 
   @Test
   void shouldStifleSystemExitCalls() {
-    SecurityManager sm = new TestRunningSecurityManager(null);
+    var sm = new TestRunningSecurityManager();
+    sm.setDelegateSecurityManager(null);
     assertThrows(SecurityException.class, () -> sm.checkExit(2));
   }
 
   @Test
   void shouldDelegateToExistingSecurityManagerIfPresent() {
-    SecurityManager permissive = new TestRunningSecurityManager(null);
+    SecurityManager permissive = new TestRunningSecurityManager();
     Permission permission = new RuntimePermission("example.permission");
-    SecurityManager restrictive =
-        new TestRunningSecurityManager(
+
+    var restrictive = new TestRunningSecurityManager();
+    restrictive.setDelegateSecurityManager(
             new SecurityManager() {
               @Override
               public void checkPermission(Permission perm) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestRunningSecurityManagerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestRunningSecurityManagerTest.java
@@ -23,14 +23,14 @@ public class TestRunningSecurityManagerTest {
 
     var restrictive = new TestRunningSecurityManager();
     restrictive.setDelegateSecurityManager(
-            new SecurityManager() {
-              @Override
-              public void checkPermission(Permission perm) {
-                if (permission == perm) {
-                  throw new SecurityException("Oh noes!");
-                }
-              }
-            });
+        new SecurityManager() {
+          @Override
+          public void checkPermission(Permission perm) {
+            if (permission == perm) {
+              throw new SecurityException("Oh noes!");
+            }
+          }
+        });
 
     // This should do nothing, but if an exception is thrown, our test fails.
     permissive.checkPermission(permission);


### PR DESCRIPTION
One of the planned clean-ups of Java that's happening is the removal of the SecurityManager. The plan is to replace it with utilities and methods that provide similar capabilities but in a more controlled way.

In order to make this process smoother, the JRE now prints a warning when `System.setSecurityManager()` is called.

A common use-case for the Security Manager is to prevent people calling `System.exit()` in untrusted code. Indeed, this particular case is called out in the JEP:
https://openjdk.org/jeps/411

Now, people using the JUnit5 runner don't really deserve to see this warning. There's nothing they can do about it, and we're fully aware of the impending System.exit apocalypse. Worse, many of users are still on Java 11, and setting the security manager there is totally legit behaviour, and in no way frowned upon.

Fortunately, Java 17 offers a system property we can call to disable the warning. That system property is `java.security.manager` with a value of `allow`. Java 17 knows that `allow` is a fine thing to say, and simply disables the warning about the security manager.

The bad news is that in Java 11 the _very self-same system property_ is used to set the security manager. In fact (!) it's used for that in Java 17 too, but only if the value isn't one of `default`, `disallow`, or `allow`. The way it does this is by passing in a class name.

So! In Java 11, calling `-Djava.security.manager=allow` tells the JRE to set the security manager to the class who's name is `allow`. You can guess how well that goes down.

Well then. That's fine. We'll just use the name of our own security manager as the value of the system property, and we're all good, right? Except our security manager was never really designed to be used this way. Much of this PR is just shuffling code around so that we can use our own security manager as the default security manager.

So, how's your yak?