### PR TITLE
Suppress warnings about security manager on java 17

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,12 @@ build --java_language_version=11
 build --tool_java_runtime_version=remotejdk_11
 build --tool_java_language_version=11
 
+build:jdk17 --java_runtime_version=remotejdk_17
+build:jdk17 --java_language_version=17
+build:jdk17 --tool_java_runtime_version=remotejdk_17
+build:jdk17 --tool_java_language_version=17
+
+
 # Make sure we get something helpful when tests fail
 test --verbose_failures
 test --test_output=errors

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,3 +39,9 @@ jobs:
           # Bazelisk will download bazel to here, ensure it is cached between runs.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
         run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test //...
+
+      - name: bazel test //... (Java 17)
+        env:
+          # Bazelisk will download bazel to here, ensure it is cached between runs.
+          XDG_CACHE_HOME: ~/.cache/bazel-repo
+        run: bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc test --config=jdk17 //...

--- a/java/private/junit5.bzl
+++ b/java/private/junit5.bzl
@@ -47,22 +47,12 @@ def java_junit5_test(name, test_class = None, runtime_deps = [], **kwargs):
     else:
         clazz = get_package_name() + name
 
-    jvm_flags = kwargs.pop("jvm_flags", [])
-    for f in jvm_flags:
-        if f.startswith("-Djava.security.manager="):
-            fail("Only the JUnit5 runner is allowed to set the security manager via a JVM flag")
-
     java_test(
         name = name,
         main_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.JUnit5Runner",
         test_class = clazz,
         runtime_deps = runtime_deps + [
             "@contrib_rules_jvm//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
-        ],
-        jvm_flags = jvm_flags + [
-            # In later versions of Java (after version 11, at least), we could set the value "allow"
-            # but earlier releases need a class name.
-            "-Djava.security.manager=com.github.bazel_contrib.contrib_rules_jvm.junit5.TestRunningSecurityManager",
         ],
         **kwargs
     )

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -50,8 +50,6 @@ public class ActualRunner implements RunsTest {
       String filter = System.getenv("TESTBRIDGE_TEST_ONLY");
       request.filters(new PatternFilter(filter));
 
-      var originalSecurityManager = System.getSecurityManager();
-
       File exitFile = getExitFile();
 
       var launcher = LauncherFactory.create(config);

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -27,6 +27,9 @@ java_library(
     name = "junit5-compile",
     srcs = glob(["*.java"]),
     javacopts = [
+        # Target Java 11, no matter which JDK we're on so that we
+        # can be sure that `SecurityManager` is present, even if
+        # someone rebuilds on a JDK that doesn't have it.
         "--release",
         "11",
     ],

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -56,7 +56,9 @@ public class JUnit5Runner {
     }
 
     // Load the java 17 toggle by reflection, because it's tied
-    // so closely to the OpenJDK
+    // so closely to the OpenJDK (it relies on the internal fields
+    // of both `sun.misc.Unsafe` and `java.lang.System`: it's a
+    // gross hack.
     try {
       var java17ToggleClazz =
           Class.forName(JAVA17_SYSTEM_EXIT_TOGGLE).asSubclass(SystemExitToggle.class);
@@ -66,6 +68,7 @@ public class JUnit5Runner {
       // this would be a combination of `ReflectiveOperationException` and
       // `SecurityException`, but the latter is scheduled for removal so
       // relying on it seems like a Bad Idea.
+      System.err.println("Failed to load Java 17 system exit override: " + e.getMessage());
 
       // Fall through
     }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java11SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java11SystemExitToggle.java
@@ -1,0 +1,24 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+public class Java11SystemExitToggle implements SystemExitToggle {
+
+  private SecurityManager previousSecurityManager;
+  private TestRunningSecurityManager testingSecurityManager;
+
+  @Override
+  public void prevent() {
+    previousSecurityManager = System.getSecurityManager();
+    testingSecurityManager = new TestRunningSecurityManager();
+    testingSecurityManager.setDelegateSecurityManager(previousSecurityManager);
+
+    System.setSecurityManager(testingSecurityManager);
+  }
+
+  @Override
+  public void allow() {
+    testingSecurityManager.allowExitCall();
+    System.setSecurityManager(testingSecurityManager);
+    testingSecurityManager = null;
+    previousSecurityManager = null;
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
@@ -1,0 +1,40 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import sun.misc.Unsafe;
+
+public class Java17SystemExitToggle extends Java11SystemExitToggle {
+
+  private SecurityManager previousSecurityManager;
+  private TestRunningSecurityManager testingSecurityManager;
+
+  public Java17SystemExitToggle() throws ReflectiveOperationException {
+    suppressSecurityManagerWarning();
+  }
+
+  private void suppressSecurityManagerWarning() throws ReflectiveOperationException {
+    Class<?> holderClazz = Class.forName("java.lang.System$CallersHolder");
+    var callersField = holderClazz.getDeclaredField("callers");
+
+    // We want to avoid opening java.lang, so let's jump through hoops
+
+    // First problem: we can't call `Unsafe.getUnsafe` directly.
+    var c = Class.forName("sun.misc.Unsafe");
+    var lookup = MethodHandles.privateLookupIn(c, MethodHandles.lookup());
+    var handle = lookup.findStaticVarHandle(c, "theUnsafe", c);
+    var unsafe = (Unsafe) handle.get();
+
+    // And we can't just grab the field easily
+    var base = unsafe.staticFieldBase(callersField);
+    long offset = unsafe.staticFieldOffset(callersField);
+    Object callers = unsafe.getObject(base, offset);
+
+    // And now we inject ourselves into the SecurityManager
+    if (Map.class.isAssignableFrom(callers.getClass())) {
+      @SuppressWarnings("unchecked")
+      Map<Class<?>, Boolean> map = Map.class.cast(callers);
+      map.put(getClass(), true);
+    }
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/NullSystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/NullSystemExitToggle.java
@@ -1,0 +1,13 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+public class NullSystemExitToggle implements SystemExitToggle {
+  @Override
+  public void prevent() {
+    // No-op
+  }
+
+  @Override
+  public void allow() {
+    // No-op
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/SystemExitToggle.java
@@ -1,0 +1,8 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+public interface SystemExitToggle {
+
+  void prevent();
+
+  void allow();
+}


### PR DESCRIPTION
Have another crack at sorting out the warning printed by the JRE when using Java 17+ and running a junit5 test.

The previous fix prevented a warning being displayed at runtime, but then caused the JRE to emit a warning that the `SecurityManager` had been set on the command line.

To avoid that, we now avoid setting the `SecurityManager` on the command line, and we're back to setting it in code.

To avoid a warning being displayed, we now "simply" check the version of Java we're using at runtime. If it's Java 11, then we use the `SecurityManager` as we did in the first place. On Java 17, however, we make a series of poorly considered choices that tie us to the OpenJDK to reach into the internals of `System` and tell it that we've already registered a `SecurityManager` instance. This prevents the warning message from being displayed.

On the off-chance that we're running on a JRE that has already had `SecurityManager` removed (I hear that may be as soon as Java 20), we provide a fall-back in the shape of a no-op control that does nothing.

All this to prevent a test calling `System.exit`....