### PR TITLE
Add `junit-platform-suite` to runner filters

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -43,7 +43,7 @@ public class ActualRunner implements RunsTest {
       var request =
           LauncherDiscoveryRequestBuilder.request()
               .selectors(List.of(classSelector))
-              .filters(includeEngines("junit-jupiter", "junit-vintage"))
+              .filters(includeEngines("junit-jupiter", "junit-vintage", "junit-platform-suite"))
               .configurationParameter(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, "true")
               .configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true");
 


### PR DESCRIPTION
This is to allow [@Suite](https://junit.org/junit5/docs/current/api/org.junit.platform.suite.api/org/junit/platform/suite/api/Suite.html) annotations to be honored when users need to leverage the [JUnit Platform Suite Engine](https://junit.org/junit5/docs/current/user-guide/#junit-platform-suite-engine) (as long as they pass the necessary runtime dependencies as documented there, of course).

Adding `junit-platform-suite` to the runner filters allows in particular that classes listed by `@SelectClasses` get actually taken into account (among other features of the JUnit Platform Suite Engine).