### PR TITLE
Register super class to suppress warning (java 17)

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
@@ -6,9 +6,6 @@ import sun.misc.Unsafe;
 
 public class Java17SystemExitToggle extends Java11SystemExitToggle {
 
-  private SecurityManager previousSecurityManager;
-  private TestRunningSecurityManager testingSecurityManager;
-
   public Java17SystemExitToggle() throws ReflectiveOperationException {
     suppressSecurityManagerWarning();
   }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
@@ -31,7 +31,7 @@ public class Java17SystemExitToggle extends Java11SystemExitToggle {
     if (Map.class.isAssignableFrom(callers.getClass())) {
       @SuppressWarnings("unchecked")
       Map<Class<?>, Boolean> map = Map.class.cast(callers);
-      map.put(getClass(), true);
+      map.put(getClass().getSuperclass(), true);
     }
   }
 }


### PR DESCRIPTION
tl;dr: register exact calling class to effectively suppress security manager warnings with java 17.

`System.setSecurityManager` being called from within methods `prevent` and `allow` of the `Java11SystemExitToggle` class, the registration its child class `Java17SystemExitToggle` performs turns out to be ineffective: warnings are still printed, and these indeed designate `Java11SystemExitToggle` as the actual caller:
```
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by com.github.bazel_contrib.contrib_rules_jvm.junit5.Java11SystemExitToggle (file:/path/to/bazel_contrib/contrib_rules_jvm/junit5/junit5-runner.jar)
WARNING: Please consider reporting this to the maintainers of com.github.bazel_contrib.contrib_rules_jvm.junit5.Java11SystemExitToggle
WARNING: System::setSecurityManager will be removed in a future release
```

The proposed change consists in registering the super class instead, which prevents these warnings from being issued.

Note: we could of course use `Java11SystemExitToggle.class` in lieu of `getClass().getSuperclass()`.
