### PR TITLE
Fix test filter greediness for method names

### DIFF
--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
@@ -134,7 +134,7 @@ public class FilteringTest {
     assertTrue(siblingTestResult.included());
 
     FilterResult nestedTestResult = filter.apply(nestedTestMethodTestDescriptor);
-    assertFalse(nestedTestResult.included(), "nested class should not be matched");
+    assertFalse(nestedTestResult.included(), "method in nested class should not be matched");
   }
 
   @Test
@@ -143,10 +143,10 @@ public class FilteringTest {
         new PatternFilter(JUnit5StyleTest.NestedTest.class.getName().replace("$", "\\$") + "#");
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
-    assertFalse(testResult.included(), "enclosing class should not be matched");
+    assertFalse(testResult.included(), "method in enclosing class should not be matched");
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
-    assertFalse(siblingTestResult.included(), "enclosing class should not be matched");
+    assertFalse(siblingTestResult.included(), "method in enclosing class should not be matched");
 
     FilterResult nestedTestResult = filter.apply(nestedTestMethodTestDescriptor);
     assertTrue(nestedTestResult.included());
@@ -186,11 +186,25 @@ public class FilteringTest {
   }
 
   @Test
-  public void shouldIncludeATestMethodIfTheFilterMatchesTheMethodName() {
+  public void shouldIncludeATestMethodIfTheFilterMatchesTheExactShortMethodName() {
+    PatternFilter filter = new PatternFilter("#alwaysPasses");
+
+    FilterResult testResult = filter.apply(testMethodTestDescriptor);
+    assertTrue(testResult.included());
+
+    FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
+    assertFalse(siblingTestResult.included(), "longer method name should not be matched");
+
+    FilterResult nestedTestResult = filter.apply(nestedTestMethodTestDescriptor);
+    assertFalse(nestedTestResult.included(), "longer method name should not be matched");
+  }
+
+  @Test
+  public void shouldIncludeATestMethodIfTheFilterMatchesTheExactLongMethodName() {
     PatternFilter filter = new PatternFilter("#alwaysPassesToo");
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
-    assertFalse(testResult.included(), "different method name should not be matched");
+    assertFalse(testResult.included(), "shorter method name should not be matched");
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());


### PR DESCRIPTION
It's a bit annoying to designate a test target and have neighboring targets hit as well, especially while debugging because breakpoints are not reached under the desired conditions.

The present change aims at preventing the `MyTest#testSomething` pattern from matching the `testSomethingElse` method in the following example:
```java
public class MyTest {
  @Test
  void testSomething() {
  }

  @Test
  void testSomethingElse() {
  }
```

With `asPredicate`, the test filter matches test methods _starting with_ the given method name:
> Creates a predicate that tests if this pattern is found in a given input string.

Unless the pattern doesn't encompass a method name, appending a `$` to the input pattern makes sure only exact method names are considered.

Note: think about filter greediness for class names.