### PR TITLE
Add dynamic test results to XML output

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
@@ -71,6 +71,11 @@ public class BazelJUnitOutputListener implements TestExecutionListener, Closeabl
   }
 
   @Override
+  public void dynamicTestRegistered(TestIdentifier testIdentifier) {
+    roots.forEach(root -> root.addDynamicTest(testIdentifier));
+  }
+
+  @Override
   public void executionStarted(TestIdentifier testIdentifier) {
     roots.forEach(root -> root.markStarted(testIdentifier));
   }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
@@ -15,10 +15,12 @@ import org.opentest4j.TestAbortedException;
 
 class TestResult extends BaseResult {
   private final TestPlan testPlan;
+  private final boolean isDynamic;
 
-  public TestResult(TestPlan testPlan, TestIdentifier id) {
+  public TestResult(TestPlan testPlan, TestIdentifier id, boolean isDynamic) {
     super(id);
     this.testPlan = testPlan;
+    this.isDynamic = isDynamic;
   }
 
   public boolean isError() {
@@ -55,11 +57,16 @@ class TestResult extends BaseResult {
 
     write(
         () -> {
-          // Massage the name
-          String name = getTestId().getLegacyReportingName();
-          int index = name.indexOf('(');
-          if (index != -1) {
-            name = name.substring(0, index);
+          String name;
+          if (isDynamic) {
+            name = getTestId().getDisplayName(); // [ordinal] name=value...
+          } else {
+            // Massage the name
+            name = getTestId().getLegacyReportingName();
+            int index = name.indexOf('(');
+            if (index != -1) {
+              name = name.substring(0, index);
+            }
           }
 
           xml.writeStartElement("testcase");


### PR DESCRIPTION
This is to add results of `@Parameterized` and other "dynamic" tests to the XML output file, otherwise these don't show up in IDE views (eg. IntelliJ IDEA `Bazel test` runs) nor in CI reports.

In the following example:
```java
import org.junit.jupiter.api.Test;
import org.junit.jupiter.params.ParameterizedTest;
import org.junit.jupiter.params.provider.ValueSource;

public class SomeTest {
    @Test
    void shouldAlwaysPass() {
    }

    @ParameterizedTest
    @ValueSource(ints = {0, 2, 4})
    void shouldBeEven(int value) {
    }
}
```
... we would get:
| prior to this change | with this change |
| -- | -- |
| ![image](https://user-images.githubusercontent.com/7901596/193561588-253fd2af-caab-473f-aa90-414dae6f4fb3.png) | ![image](https://user-images.githubusercontent.com/7901596/193561493-85bd7833-044d-4978-8b9f-1ffe43a7068c.png) |
