### PR TITLE
Generate test targets for _only_ separate tests

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -310,13 +310,15 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 					srcs = append(srcs, strings.TrimPrefix(src.pathRelativeToBazelWorkspaceRoot, args.Rel+"/"))
 				}
 			}
-			generateJavaTestSuite(
-				suiteName,
-				srcs,
-				packageNames,
-				testJavaImportsWithHelpers,
-				&res,
-			)
+			if len(srcs) > 0 {
+				generateJavaTestSuite(
+					suiteName,
+					srcs,
+					packageNames,
+					testJavaImportsWithHelpers,
+					&res,
+				)
+			}
 
 			sortedSeparateTestJavaFiles := sorted_set.NewSortedSetFn([]javaFile{}, javaFileLess)
 			for src := range separateTestJavaFiles {
@@ -370,9 +372,8 @@ func accumulateJavaFile(cfg *javaconfig.Config, testJavaFiles, testHelperJavaFil
 				}
 			}
 		}
-		if len(perFileAttrs) == 0 {
-			testJavaFiles.Add(file)
-		} else {
+		testJavaFiles.Add(file)
+		if len(perFileAttrs) > 0 {
 			separateTestJavaFiles[file] = perFileAttrs
 		}
 	} else {

--- a/java/gazelle/testdata/attribute_setting/src/test/com/onlyflaky/myproject/BUILD.out
+++ b/java/gazelle/testdata/attribute_setting/src/test/com/onlyflaky/myproject/BUILD.out
@@ -1,0 +1,17 @@
+load("@contrib_rules_jvm//java:defs.bzl", "java_junit5_test")
+
+java_junit5_test(
+    name = "RandomTest",
+    srcs = ["RandomTest.java"],
+    flaky = True,
+    test_class = "com.example.myproject.RandomTest",
+    runtime_deps = [
+        "@maven//:org_junit_jupiter_junit_jupiter_engine",
+        "@maven//:org_junit_platform_junit_platform_launcher",
+        "@maven//:org_junit_platform_junit_platform_reporting",
+    ],
+    deps = [
+        "//src/main/com/example/annotation",
+        "@maven//:org_junit_jupiter_junit_jupiter_api",
+    ],
+)

--- a/java/gazelle/testdata/attribute_setting/src/test/com/onlyflaky/myproject/RandomTest.java
+++ b/java/gazelle/testdata/attribute_setting/src/test/com/onlyflaky/myproject/RandomTest.java
@@ -1,0 +1,18 @@
+package com.example.myproject;
+
+import com.example.annotation.FlakyTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@FlakyTest
+public class RandomTest {
+  @Test
+  public void unreliableTest() {
+    Random random = new Random();
+    int r = random.nextInt(2);
+    assertEquals(r, 0);
+  }
+}


### PR DESCRIPTION
Previously we would only generate any targets if at least one was not meant to be separate. This was a bug.