### PR TITLE
Fix NPE when translating `null` exception messages to XML

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
@@ -89,7 +89,7 @@ class TestResult extends BaseResult {
               return;
             }
 
-            xml.writeAttribute("message", throwable.getMessage());
+            xml.writeAttribute("message", String.valueOf(throwable.getMessage())); // or "null"
             xml.writeAttribute("type", throwable.getClass().getName());
 
             StringWriter stringWriter = new StringWriter();


### PR DESCRIPTION
`Throwable`s may hold `null` detail messages (as [documented](https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#Throwable--)), which should be taken into account when translating `TestResult`s to XML, otherwise NPEs get thrown:
```
java.lang.NullPointerException: Cannot invoke "String.length()" because "content" is null
    at java.xml/com.sun.xml.internal.stream.writers.XMLStreamWriterImpl.writeXMLContent(XMLStreamWriterImpl.java:1487)
    at java.xml/com.sun.xml.internal.stream.writers.XMLStreamWriterImpl.writeAttribute(XMLStreamWriterImpl.java:554)
    at com.github.bazel_contrib.contrib_rules_jvm.junit5.TestResult.lambda(TestResult.java:92)
    at com.github.bazel_contrib.contrib_rules_jvm.junit5.BaseResult.write(BaseResult.java:78)
    at com.github.bazel_contrib.contrib_rules_jvm.junit5.TestResult.toXml(TestResult.java:58)
    [...]
```

In the following example, the present change makes sure a `TimeoutException` without detail message (i.e. `null`) is properly rendered, which also fixes unbalanced quotes in the resulting `test.xml` file:
```diff
     <testsuite name="my.package_.MyTest" tests="1" failures="1" errors="0" package="">
       <properties />
       <testcase name="shouldPass" classname="my.package_.MyTest" time="5.06">
-        <!--             v unclosed quotation mark -->
-        <failure message="></failure>
+        <!--             vvvvvv `String.valueOf(null)` -->
+        <failure message="null" type="java.util.concurrent.TimeoutException">java.util.concurrent.TimeoutException
+       at java.base/java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1960)
+       at java.base/java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2095)
+       [...]
+       at com.github.bazel_contrib.contrib_rules_jvm.junit5.ActualRunner.run(ActualRunner.java:56)
+       at com.github.bazel_contrib.contrib_rules_jvm.junit5.JUnit5Runner.main(JUnit5Runner.java:37)
+</failure>
       </testcase>
     </testsuite>
   </testsuite>
```