### PR TITLE
Allow finding and processing a classname starting with an underscore

### DIFF
--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -19,7 +19,7 @@ func NewImport(imp string) *Import {
 		if unicode.IsUpper(rune(parts[i][0])) {
 			break
 		}
-        // Assume that a _ prefix denotes a class not a package.
+		// Assume that a _ prefix denotes a class not a package.
 		// This isn't a strong convention in the Java community, but has been spotted in the wild.
 		// If it breaks (i.e. we discover packages starting with underscores), we may tweak this heuristic further.
 		//

--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -19,6 +19,10 @@ func NewImport(imp string) *Import {
 		if unicode.IsUpper(rune(parts[i][0])) {
 			break
 		}
+        // Assume that a _ prefix denotes a class not a package.
+		// This isn't a strong convention in the Java community, but has been spotted in the wild.
+		// If it breaks (i.e. we discover packages starting with underscores), we may tweak this heuristic further.
+		//
 		// The "_TESTONLY" comes from the parser to identify cases where there is both a
 		// java_library and a java_test_suite in the same file, and a package may need access
 		// to the test library. see java/gazelle/generate.go for details.

--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -16,8 +16,14 @@ func NewImport(imp string) *Import {
 	parts := strings.Split(imp, ".")
 	i := 0
 	for ; i < len(parts); i++ {
-		if unicode.IsUpper(rune(parts[i][0])) || strings.HasPrefix(parts[i], "_") {
+		if unicode.IsUpper(rune(parts[i][0])) {
 			break
+		}
+		// The "_TESTONLY" comes from the parser to identify cases where there is both a
+		// java_library and a java_test_suite in the same file, and a package may need access
+		// to the test library. see java/gazelle/generate.go for details.
+		if strings.HasPrefix(parts[i], "_") && !strings.HasPrefix(parts[i], "_TESTONLY") {
+		    break
 		}
 	}
 

--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -23,7 +23,7 @@ func NewImport(imp string) *Import {
 		// java_library and a java_test_suite in the same file, and a package may need access
 		// to the test library. see java/gazelle/generate.go for details.
 		if strings.HasPrefix(parts[i], "_") && !strings.HasPrefix(parts[i], "_TESTONLY") {
-		    break
+			break
 		}
 	}
 

--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -16,7 +16,7 @@ func NewImport(imp string) *Import {
 	parts := strings.Split(imp, ".")
 	i := 0
 	for ; i < len(parts); i++ {
-		if unicode.IsUpper(rune(parts[i][0])) {
+		if unicode.IsUpper(rune(parts[i][0])) || strings.HasPrefix(parts[i], "_") {
 			break
 		}
 	}

--- a/java/gazelle/private/java/import.go
+++ b/java/gazelle/private/java/import.go
@@ -33,6 +33,7 @@ func (i *Import) Path() string {
 
 var stdlibPrefixes = []string{
 	"com.sun.management.",
+	"com.sun.net.httpserver.",
 	"java.",
 	"javax.annotation.security.",
 	"javax.crypto.",
@@ -42,6 +43,8 @@ var stdlibPrefixes = []string{
 	"javax.security.",
 	"javax.xml.",
 	"jdk.",
+	"org.w3c.dom.",
+	"org.xml.sax.",
 	"sun.",
 }
 


### PR DESCRIPTION
This is an unusual corner case, but we've found that some class names can begin with an underscore. Make sure that the Java import processor can correctly identify these, separate them properly, and update the dependencies as needed. 