### PR TITLE
checkstyle: Short timeout by default

### DIFF
--- a/java/private/checkstyle.bzl
+++ b/java/private/checkstyle.bzl
@@ -42,7 +42,7 @@ def _checkstyle_impl(ctx):
         ),
     ]
 
-checkstyle_test = rule(
+_checkstyle_test = rule(
     _checkstyle_impl,
     attrs = {
         "srcs": attr.label_list(
@@ -65,3 +65,11 @@ checkstyle_test = rule(
     test = True,
     doc = """Use checkstyle to lint the `srcs`.""",
 )
+
+def checkstyle_test(name, size = "medium", timeout = "short", **kwargs):
+    _checkstyle_test(
+        name = name,
+        size = size,
+        timeout = timeout,
+        **kwargs
+    )

--- a/java/private/library.bzl
+++ b/java/private/library.bzl
@@ -22,8 +22,6 @@ def _create_lint_tests(name, **kwargs):
             # regardless of the library or test tags (e.g. even if we exclude
             # sidecar tests, we want to lint them).
             tags = ["lint", "checkstyle", "java-checkstyle"],
-            size = "small",
-            timeout = "moderate",
         )
 
     pmd = get_lint_config("java-pmd", tags)


### PR DESCRIPTION
Mark check style test add medium and short.

This reduces noise with the `--test_verbose_timeout_warnings` option of Bazel.