### PR TITLE
[junit5] Also filter dynamically registered tests

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/PatternFilter.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/PatternFilter.java
@@ -34,7 +34,7 @@ public class PatternFilter implements PostDiscoveryFilter {
 
   @Override
   public FilterResult apply(TestDescriptor object) {
-    if (!object.isTest()) {
+    if (!object.isTest() && !object.mayRegisterTests()) {
       return FilterResult.included("Including container: " + object.getDisplayName());
     }
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.engine.config.JupiterConfiguration;
 import org.junit.jupiter.engine.descriptor.ClassTestDescriptor;
 import org.junit.jupiter.engine.descriptor.JupiterEngineDescriptor;
 import org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor;
+import org.junit.jupiter.engine.descriptor.TestTemplateTestDescriptor;
 import org.junit.platform.engine.ConfigurationParameters;
 import org.junit.platform.engine.FilterResult;
 import org.junit.platform.engine.UniqueId;
@@ -23,6 +24,7 @@ public class FilteringTest {
   private ClassTestDescriptor classTestDescriptor;
   private ClassTestDescriptor nestedClassTestDescriptor;
   private TestMethodTestDescriptor testMethodTestDescriptor;
+  private TestTemplateTestDescriptor testTemplateTestDescriptor;
   private TestMethodTestDescriptor siblingTestMethodTestDescriptor;
   private TestMethodTestDescriptor nestedTestMethodTestDescriptor;
 
@@ -38,16 +40,19 @@ public class FilteringTest {
     testMethodTestDescriptor =
         new TestMethodTestDescriptor(
             classId.append("method", "bar"), JUnit5StyleTest.class, method, config);
+    testTemplateTestDescriptor =
+        new TestTemplateTestDescriptor(
+            classId.append("method", "baz"), JUnit5StyleTest.class, method, config);
     Method siblingMethod = JUnit5StyleTest.class.getMethod("alwaysPassesToo");
     siblingTestMethodTestDescriptor =
         new TestMethodTestDescriptor(
-            classId.append("method", "baz"), JUnit5StyleTest.class, siblingMethod, config);
+            classId.append("method", "qux"), JUnit5StyleTest.class, siblingMethod, config);
     nestedClassTestDescriptor =
         new ClassTestDescriptor(classId, JUnit5StyleTest.NestedTest.class, config);
     Method nestedMethod = JUnit5StyleTest.NestedTest.class.getMethod("alwaysPassesToo");
     nestedTestMethodTestDescriptor =
         new TestMethodTestDescriptor(
-            classId.append("method", "qux"),
+            classId.append("method", "quux"),
             JUnit5StyleTest.NestedTest.class,
             nestedMethod,
             config);
@@ -65,6 +70,9 @@ public class FilteringTest {
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
+
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());
@@ -89,6 +97,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());
 
@@ -112,6 +123,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertFalse(testResult.included());
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertFalse(dynamicTestResult.included());
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertFalse(siblingTestResult.included());
 
@@ -130,6 +144,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());
 
@@ -144,6 +161,9 @@ public class FilteringTest {
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertFalse(testResult.included(), "method in enclosing class should not be matched");
+
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertFalse(dynamicTestResult.included(), "method in enclosing class should not be matched");
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertFalse(siblingTestResult.included(), "method in enclosing class should not be matched");
@@ -164,6 +184,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());
 
@@ -177,6 +200,9 @@ public class FilteringTest {
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertFalse(testResult.included());
+
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertFalse(dynamicTestResult.included());
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertFalse(siblingTestResult.included());
@@ -192,6 +218,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertFalse(siblingTestResult.included(), "longer method name should not be matched");
 
@@ -206,6 +235,9 @@ public class FilteringTest {
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertFalse(testResult.included(), "shorter method name should not be matched");
 
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertFalse(dynamicTestResult.included(), "shorter method name should not be matched");
+
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());
 
@@ -219,6 +251,9 @@ public class FilteringTest {
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
+
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
 
     FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
     assertTrue(siblingTestResult.included());


### PR DESCRIPTION
This change is a follow-up to [Add dynamic test results to XML output](https://github.com/bazel-contrib/rules_jvm/pull/94), where only partial support for dynamically registered tests was added.

What was missing is that dynamic tests were always matched, disregarding any selected pattern since `TestDescriptor.isTest()` would _always evaluate to `false`_ for them (`isStaticTest` would be more accurate).

Such tests get indeed registered through special "containers":
- either a [TestFactoryTestDescriptor](https://junit.org/junit5/docs/current/api/org.junit.jupiter.engine/org/junit/jupiter/engine/descriptor/TestFactoryTestDescriptor.html),
- or a [TestTemplateTestDescriptor](https://junit.org/junit5/docs/current/api/org.junit.jupiter.engine/org/junit/jupiter/engine/descriptor/TestTemplateTestDescriptor.html).

The fact that both of them (and potentially other `TestDescriptor` implementations) act as _test sources_ could be determined by an additional evaluation of `TestDescriptor.mayRegisterTests()`.

`FilteringTest` methods get here augmented in order to cover a `TestTemplateTestDescriptor` the same way as one of the `TestMethodTestDescriptor`s. Prior to adjusting `PatternFilter.apply`, following test methods were then failing:
- `shouldNotIncludeATestMethodIfTheFilterDoesNotMatchTheMethodName`,
- `ifFilterIsSetButNoTestsMatchTheContainersAreIncluded`,
- `shouldIncludeANestedTestMethodIfTheFilterIsJustTheNestedClassName`,
- `shouldIncludeATestMethodIfTheFilterMatchesTheExactLongMethodName`.

In the below synthetic example, the present change would prevent the `MyTest#testStatic` pattern from matching the `testDynamic` method:
```java
public class MyTest {
  @Test
  void testStatic() {
  }

  @ParameterizedTest
  @ValueSource(booleans = {false, true})
  void testDynamic(boolean flag) {
  }
}
```