### PR TITLE
[junit5] Fix serialization of illegal XML characters

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
@@ -97,7 +97,7 @@ class TestResult extends BaseResult {
               return;
             }
 
-            xml.writeAttribute("message", String.valueOf(throwable.getMessage())); // or "null"
+            xml.writeAttribute("message", String.valueOf(throwable.getMessage()));
             xml.writeAttribute("type", throwable.getClass().getName());
 
             StringWriter stringWriter = new StringWriter();

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/JunitOutputXmlTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/JunitOutputXmlTest.java
@@ -83,8 +83,7 @@ public class JunitOutputXmlTest {
   }
 
   @Test
-  public void disabledTestsAreMarkedAsSkipped()
-      throws XMLStreamException, ParserConfigurationException, IOException, SAXException {
+  public void disabledTestsAreMarkedAsSkipped() {
     TestSuiteResult suite = new TestSuiteResult(identifier);
     suite.markSkipped("Not today");
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/JunitOutputXmlTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/JunitOutputXmlTest.java
@@ -35,7 +35,6 @@ public class JunitOutputXmlTest {
 
   private TestDescriptor testDescriptor = new StubbedTestDescriptor(createId("descriptors"));
   private TestIdentifier identifier = TestIdentifier.from(testDescriptor);
-  ;
 
   @Test
   public void testResultCanBeDisabled() {


### PR DESCRIPTION
This is to fix invalid XML when a test fails due to an exception whose message contains illegal XML characters, leading to decoding exceptions like:
> org.xml.sax.SAXParseException; lineNumber: 3; columnNumber: 30; An invalid XML character (Unicode: 0x0) was found in the value of attribute "message" and element is "failure".

This may happen when testing invalid protobuf `Message`s, `UUID` bytes, etc.

A simple solution would be to leverage guava's `XmlEscapers` or Apache's `StringEscapeUtils`, but that would infringe:
```
        # The only dependencies here are those required to run
        # a junit5 test. We try not to pollute the classpath, so
        # be very careful when adding new deps here.
```

The present fix therefore mimics what was done in the upstream JUnit 5 project: [Replace illegal chars with their char reference](https://github.com/junit-team/junit5/pull/2275).

Paying some tech debt, the change also adds a test that should have been part of [Fix NPE when translating null exception messages to XML](https://github.com/bazel-contrib/rules_jvm/pull/96) (related).
