### PR TITLE
Fix time attribute format in JUnit 5 test results

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
@@ -4,6 +4,8 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.math.RoundingMode;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Optional;
 import javax.xml.stream.XMLStreamWriter;
 import org.junit.AssumptionViolatedException;
@@ -14,6 +16,9 @@ import org.junit.platform.reporting.legacy.LegacyReportingUtils;
 import org.opentest4j.TestAbortedException;
 
 class TestResult extends BaseResult {
+  private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS =
+      new DecimalFormatSymbols(Locale.ROOT);
+
   private final TestPlan testPlan;
   private final boolean isDynamic;
 
@@ -59,7 +64,7 @@ class TestResult extends BaseResult {
 
   @Override
   public void toXml(XMLStreamWriter xml) {
-    DecimalFormat decimalFormat = new DecimalFormat("#.##");
+    DecimalFormat decimalFormat = new DecimalFormat("#.##", DECIMAL_FORMAT_SYMBOLS);
     decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
 
     write(


### PR DESCRIPTION
This PR sets the root locale for the duration formats in the JUnit test result XMLs since the decimal separator is important for IntelliJ IDEA test reports. Currently, the format depends on the machine’s default locale (e.g., in my case, it was `en_NL`).

The test report with `en_NL` as the default locale before this change:
<img width="839" alt="Screenshot 2022-11-29 at 13 08 53" src="https://user-images.githubusercontent.com/7688949/204526378-63eaebde-0150-449c-ac23-e3b7750ff2e7.png">

The test report with `en_NL` as the default locale after this change:
<img width="826" alt="Screenshot 2022-11-29 at 13 09 28" src="https://user-images.githubusercontent.com/7688949/204526394-0c1cf4ae-8ce8-4161-884b-438773756883.png">

Note that providing a non-parsable value to the [time attribute in `testcase`](https://github.com/bazelbuild/intellij/blob/0edc361d5906f5edbb1b9002cd7ad425a317c89c/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java#L146) only breaks the duration in test report, assuming its type is string. However, the [time attribute in `testsuite`](https://github.com/bazelbuild/intellij/blob/0edc361d5906f5edbb1b9002cd7ad425a317c89c/base/src/com/google/idea/blaze/base/run/smrunner/BlazeXmlSchema.java#L82) is double, and passing a non-parsable value to it causes `No tests were found` error, even when tests pass successfully.