### PR TITLE
Add `.co` to list of common package prefixes

### DIFF
--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -1,5 +1,5 @@
 # Common package prefixes, in the order we want to check for them
-_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.")
+_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.")
 
 # By default bazel computes the name of test classes based on the
 # standard Maven directory structure, which we may not always use,


### PR DESCRIPTION
I work for a company called `du.co` and am looking to migrate to bazel. Any chance of adding `.co.` as a common package prefix?