### PR TITLE
Add `.me` to list of common package prefixes

### DIFF
--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -1,5 +1,5 @@
 # Common package prefixes, in the order we want to check for them
-_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.")
+_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.", ".me.")
 
 # By default bazel computes the name of test classes based on the
 # standard Maven directory structure, which we may not always use,


### PR DESCRIPTION
I’m working on my personal project and I use `me.luangong.*` as the package prefix. Can we also treat `.me` as a common package prefix? Thanks!

See #118 and #104 for reference.