### PR TITLE
fix(#104): Allow custom package prefixes

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -27,6 +27,7 @@ def create_jvm_test_suite(
         tags = [],
         visibility = None,
         size = None,
+        package_prefixes = [],
         **kwargs):
     """Generate a test suite for rules that "feel" like `java_test`.
 
@@ -92,7 +93,7 @@ def create_jvm_test_suite(
         suffix = src.rfind(".")
         test_name = src[:suffix]
         tests.append(test_name)
-        test_class = get_class_name(package, src)
+        test_class = get_class_name(package, src, package_prefixes)
 
         define_test(
             name = test_name,

--- a/java/private/junit5.bzl
+++ b/java/private/junit5.bzl
@@ -22,7 +22,7 @@ JUNIT5_DEPS = junit5_deps()
 
 JUNIT5_VINTAGE_DEPS = junit5_vintage_deps()
 
-def java_junit5_test(name, test_class = None, runtime_deps = [], **kwargs):
+def java_junit5_test(name, test_class = None, runtime_deps = [], package_prefixes = [], **kwargs):
     """Run junit5 tests using Bazel.
 
     This is designed to be a drop-in replacement for `java_test`, but
@@ -51,7 +51,7 @@ def java_junit5_test(name, test_class = None, runtime_deps = [], **kwargs):
     if test_class:
         clazz = test_class
     else:
-        clazz = get_package_name() + name
+        clazz = get_package_name(package_prefixes) + name
 
     java_test(
         name = name,

--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -4,10 +4,12 @@ _PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.", ".me.")
 # By default bazel computes the name of test classes based on the
 # standard Maven directory structure, which we may not always use,
 # so try to compute the correct package name.
-def get_package_name():
+def get_package_name(prefixes = []):
     pkg = native.package_name().replace("/", ".")
+    if len(prefixes) == 0:
+        prefixes = _PREFIXES
 
-    for prefix in _PREFIXES:
+    for prefix in prefixes:
         idx = pkg.find(prefix)
         if idx != -1:
             return pkg[idx + 1:] + "."
@@ -15,12 +17,15 @@ def get_package_name():
     return ""
 
 # Converts a file name into what is hopefully a valid class name.
-def get_class_name(package, src):
+def get_class_name(package, src, prefixes = []):
     # Strip the suffix from the source
     idx = src.rindex(".")
     name = src[:idx].replace("/", ".")
 
-    for prefix in _PREFIXES:
+    if len(prefixes) == 0:
+        prefixes = _PREFIXES
+
+    for prefix in prefixes:
         idx = name.find(prefix)
         if idx != -1:
             return name[idx + 1:]
@@ -29,7 +34,7 @@ def get_class_name(package, src):
     # safe to add the class name. While `get_package_name` does
     # the right thing, the parameter passed by a user may not
     # so we shall check once we have `pkg` just to be safe.
-    pkg = package if package else get_package_name()
+    pkg = package if package else get_package_name(prefixes)
     if len(pkg) and not pkg.endswith("."):
         pkg = pkg + "."
 

--- a/java/test/custom/github/bazel_contrib/contrib_rules_jvm/BUILD.bazel
+++ b/java/test/custom/github/bazel_contrib/contrib_rules_jvm/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//java:defs.bzl", "java_test_suite", "junit5_deps")
+
+# Ignore this directory because of the wrong package name.
+# gazelle:ignore
+
+PACKAGE_PREFIX_NAME_TEST = [
+    "CustomPackageNameTest.java",
+]
+
+# Test that we can set known package prefixes. We do this by
+# setting the `package_prefixes` property, overriding the
+# assumed known prefixes
+java_test_suite(
+    name = "custom-prefix-tests",
+    size = "small",
+    srcs = PACKAGE_PREFIX_NAME_TEST,
+    package_prefixes = [".custom."],
+    runner = "junit5",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)

--- a/java/test/custom/github/bazel_contrib/contrib_rules_jvm/CustomPackageNameTest.java
+++ b/java/test/custom/github/bazel_contrib/contrib_rules_jvm/CustomPackageNameTest.java
@@ -1,0 +1,13 @@
+// Note: the package name is not the same as the directory name for a reason.
+// See this package's `BUILD.bazel` file for more information
+package custom.github.bazel_contrib.contrib_rules_jvm;
+
+import org.junit.jupiter.api.Test;
+
+public class CustomPackageNameTest {
+
+  @Test
+  void shouldBeAbleToBeRun() {
+    // This test does nothing
+  }
+}


### PR DESCRIPTION
First of all: Thanks a lot for these rules!

Attempt at making the package prefixes configurable, instead of populating _PREFIXES with all known values.

I need suppport for `.no.` domains for example, and based on #104 there are many more wishes for package prefixes out there.

Feedback and improvements are welcome!