### PR TITLE
Add support for the Junit5 tags to limit tests withing a class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ The linters are configured using specific rules. The mappings are:
 
 These rules require Java 11 or above.
 
-The gazelle plugin requires Go 1.18 or above.
-
 ## Java Rules
 
 [arl]: https://github.com/apple/apple_rules_lint
@@ -84,27 +82,6 @@ checkstyle_config(<a href="#checkstyle_config-name">name</a>, <a href="#checksty
 | <a id="checkstyle_config-config_file"></a>config_file |  The config file to use for all checkstyle tests   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="checkstyle_config-data"></a>data |  Additional files to make available to Checkstyle such as any included XML files   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | optional | [] |
 | <a id="checkstyle_config-output_format"></a>output_format |  Output format to use. Defaults to plain   | String | optional | "plain" |
-
-
-<a id="#checkstyle_test"></a>
-
-## checkstyle_test
-
-<pre>
-checkstyle_test(<a href="#checkstyle_test-name">name</a>, <a href="#checkstyle_test-config">config</a>, <a href="#checkstyle_test-output_format">output_format</a>, <a href="#checkstyle_test-srcs">srcs</a>)
-</pre>
-
-Use checkstyle to lint the `srcs`.
-
-**ATTRIBUTES**
-
-
-| Name  | Description | Type | Mandatory | Default |
-| :------------- | :------------- | :------------- | :------------- | :------------- |
-| <a id="checkstyle_test-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
-| <a id="checkstyle_test-config"></a>config |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | @contrib_rules_jvm//java:checkstyle-default-config |
-| <a id="checkstyle_test-output_format"></a>output_format |  Output Format can be plain or xml. Defaults to plain   | String | optional | "plain" |
-| <a id="checkstyle_test-srcs"></a>srcs |  -   | <a href="https://bazel.build/docs/build-ref.html#labels">List of labels</a> | required |  |
 
 
 <a id="#pmd_ruleset"></a>
@@ -235,6 +212,27 @@ checkstyle_binary(
 | <a id="checkstyle_binary-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
+<a id="#checkstyle_test"></a>
+
+## checkstyle_test
+
+<pre>
+checkstyle_test(<a href="#checkstyle_test-name">name</a>, <a href="#checkstyle_test-size">size</a>, <a href="#checkstyle_test-timeout">timeout</a>, <a href="#checkstyle_test-kwargs">kwargs</a>)
+</pre>
+
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="checkstyle_test-name"></a>name |  <p align="center"> - </p>   |  none |
+| <a id="checkstyle_test-size"></a>size |  <p align="center"> - </p>   |  <code>"medium"</code> |
+| <a id="checkstyle_test-timeout"></a>timeout |  <p align="center"> - </p>   |  <code>"short"</code> |
+| <a id="checkstyle_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <a id="#java_binary"></a>
 
 ## java_binary
@@ -282,7 +280,8 @@ Adds linting tests to `rules_jvm_external`'s `java_export`
 ## java_junit5_test
 
 <pre>
-java_junit5_test(<a href="#java_junit5_test-name">name</a>, <a href="#java_junit5_test-test_class">test_class</a>, <a href="#java_junit5_test-runtime_deps">runtime_deps</a>, <a href="#java_junit5_test-package_prefixes">package_prefixes</a>, <a href="#java_junit5_test-kwargs">kwargs</a>)
+java_junit5_test(<a href="#java_junit5_test-name">name</a>, <a href="#java_junit5_test-test_class">test_class</a>, <a href="#java_junit5_test-runtime_deps">runtime_deps</a>, <a href="#java_junit5_test-package_prefixes">package_prefixes</a>, <a href="#java_junit5_test-jvm_flags">jvm_flags</a>, <a href="#java_junit5_test-include_tags">include_tags</a>,
+                 <a href="#java_junit5_test-exclude_tags">exclude_tags</a>, <a href="#java_junit5_test-kwargs">kwargs</a>)
 </pre>
 
 Run junit5 tests using Bazel.
@@ -290,6 +289,13 @@ Run junit5 tests using Bazel.
 This is designed to be a drop-in replacement for `java_test`, but
 rather than using a JUnit4 runner it provides support for using
 JUnit5 directly. The arguments are the same as used by `java_test`.
+
+
+By default Bazel, and by extension this rule, assumes you want to always run all of the tests in a class file.
+The include_tags and exclude_tags allows for selectively running specific tests within a single class file based
+on your use of the `@Tag` Junit5 annotations.
+Please see https://junit.org/junit5/docs/current/user-guide/#running-tests-tags
+for more information about using JUnit5 tag annotation to control test execution.
 
 The generated target does not include any JUnit5 dependencies. If
 you are using the standard `@maven` namespace for your
@@ -313,7 +319,10 @@ its goals, but this is not complete or available yet.
 | <a id="java_junit5_test-name"></a>name |  The name of the test.   |  none |
 | <a id="java_junit5_test-test_class"></a>test_class |  The Java class to be loaded by the test runner. If not specified, the class name will be inferred from a combination of the current bazel package and the <code>name</code> attribute.   |  <code>None</code> |
 | <a id="java_junit5_test-runtime_deps"></a>runtime_deps |  <p align="center"> - </p>   |  <code>[]</code> |
-| <a id="java_junit5_test-package_prefixes"></a>package_prefixes | Package prefixes to look for when infering class names for tests, prefixed and postfixed with `.`. Example: `[".com.", ".no."]` |  <code>[]</code> |
+| <a id="java_junit5_test-package_prefixes"></a>package_prefixes |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="java_junit5_test-jvm_flags"></a>jvm_flags |  <p align="center"> - </p>   |  <code>[]</code> |
+| <a id="java_junit5_test-include_tags"></a>include_tags |  Junit5 tag expressions to include execution of tagged tests.   |  <code>[]</code> |
+| <a id="java_junit5_test-exclude_tags"></a>exclude_tags |  Junit tag expressions to exclude execution of tagged tests.   |  <code>[]</code> |
 | <a id="java_junit5_test-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
@@ -360,8 +369,7 @@ Adds linting tests to Bazel's own `java_test`
 ## java_test_suite
 
 <pre>
-java_test_suite(<a href="#java_test_suite-name">name</a>, <a href="#java_test_suite-srcs">srcs</a>, <a href="#java_test_suite-runner">runner</a>, <a href="#java_test_suite-test_suffixes">test_suffixes</a>, <a href="#java_test_suite-package">package</a>, <a href="#java_test_suite-deps">deps</a>, <a href="#java_test_suite-runtime_deps">runtime_deps</a>, <a href="#java_test_suite-tags">tags</a>, <a href="#java_test_suite-visibility">visibility</a>,
-                <a href="#java_test_suite-size">size</a>, <a href="#java_test_suite-package_prefixes">package_prefixes</a>, <a href="#java_test_suite-kwargs">kwargs</a>)
+java_test_suite(<a href="#java_test_suite-name">name</a>, <a href="#java_test_suite-srcs">srcs</a>, <a href="#java_test_suite-runner">runner</a>, <a href="#java_test_suite-test_suffixes">test_suffixes</a>, <a href="#java_test_suite-package">package</a>, <a href="#java_test_suite-deps">deps</a>, <a href="#java_test_suite-runtime_deps">runtime_deps</a>, <a href="#java_test_suite-size">size</a>, <a href="#java_test_suite-kwargs">kwargs</a>)
 </pre>
 
 Create a suite of java tests from `*Test.java` files.
@@ -392,10 +400,7 @@ attribute to allow all the tests to be run in one go.
 | <a id="java_test_suite-package"></a>package |  The package name used by the tests. If not set, this is inferred from the current bazel package name.   |  <code>None</code> |
 | <a id="java_test_suite-deps"></a>deps |  A list of <code>java_*</code> dependencies.   |  <code>None</code> |
 | <a id="java_test_suite-runtime_deps"></a>runtime_deps |  A list of <code>java_*</code> dependencies needed at runtime.   |  <code>[]</code> |
-| <a id="java_test_suite-tags"></a>tags |  <p align="center"> - </p>   |  <code>[]</code> |
-| <a id="java_test_suite-visibility"></a>visibility |  <p align="center"> - </p>   |  <code>None</code> |
 | <a id="java_test_suite-size"></a>size |  The size of the test, passed to <code>java_test</code>   |  <code>None</code> |
-| <a id="java_test_suite-package_prefixes"></a>package_prefixes | Package prefixes to look for when infering class names for tests, prefixed and postfixed with `.`. Example: `[".com.", ".no."]`  |  <code>[]</code> |
 | <a id="java_test_suite-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
 
 
@@ -526,7 +531,7 @@ file you need to do the following:
    
    pinned_maven_install()
    ```
-2. Run `bazel run //tools:freeze-deps -- --repo <repo name> --zip
+2. Run `./tools/freeze-deps.py --repo <repo name> --zip
    <path/to/dependency.zip>`. The `<repo name>` matches the name used
    for the `maven_install()` rule above. This will pin the
    dependencies then collect them into the zip file.

--- a/java/private/junit5.bzl
+++ b/java/private/junit5.bzl
@@ -22,12 +22,18 @@ JUNIT5_DEPS = junit5_deps()
 
 JUNIT5_VINTAGE_DEPS = junit5_vintage_deps()
 
-def java_junit5_test(name, test_class = None, runtime_deps = [], package_prefixes = [], **kwargs):
+def java_junit5_test(name, test_class = None, runtime_deps = [], package_prefixes = [], jvm_flags = [], include_tags = [], exclude_tags = [], **kwargs):
     """Run junit5 tests using Bazel.
 
     This is designed to be a drop-in replacement for `java_test`, but
     rather than using a JUnit4 runner it provides support for using
     JUnit5 directly. The arguments are the same as used by `java_test`.
+
+    By default Bazel, and by extension this rule, assumes you want to always run all of the tests in a class file.
+    The include_tags and exclude_tags allows for selectively running specific tests within a single class file based
+    on your use of the `@Tag` Junit5 annotations.
+    Please see https://junit.org/junit5/docs/current/user-guide/#running-tests-tags
+    for more information about using JUnit5 tag annotation to control test execution.
 
     The generated target does not include any JUnit5 dependencies. If
     you are using the standard `@maven` namespace for your
@@ -47,11 +53,19 @@ def java_junit5_test(name, test_class = None, runtime_deps = [], package_prefixe
       test_class: The Java class to be loaded by the test runner. If not
         specified, the class name will be inferred from a combination of
         the current bazel package and the `name` attribute.
+      include_tags: Junit5 tag expressions to include execution of tagged tests.
+      exclude_tags: Junit tag expressions to exclude execution of tagged tests.
     """
     if test_class:
         clazz = test_class
     else:
         clazz = get_package_name(package_prefixes) + name
+
+    if include_tags:
+        jvm_flags = jvm_flags + ["-DJUNIT5_INCLUDE_TAGS=" + ",".join(include_tags)]
+
+    if exclude_tags:
+        jvm_flags = jvm_flags + ["-DJUNIT5_EXCLUDE_TAGS=" + ",".join(exclude_tags)]
 
     java_test(
         name = name,
@@ -60,5 +74,6 @@ def java_junit5_test(name, test_class = None, runtime_deps = [], package_prefixe
         runtime_deps = runtime_deps + [
             "@contrib_rules_jvm//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
         ],
+        jvm_flags = jvm_flags,
         **kwargs
     )

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -18,6 +18,7 @@ import java.util.stream.Collectors;
 import org.junit.platform.engine.TestEngine;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.LauncherConstants;
+import org.junit.platform.launcher.TagFilter;
 import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
@@ -58,6 +59,16 @@ public class ActualRunner implements RunsTest {
 
       String filter = System.getenv("TESTBRIDGE_TEST_ONLY");
       request.filters(new PatternFilter(filter));
+
+      String includeTags = System.getProperty("JUNIT5_INCLUDE_TAGS");
+      if (includeTags != null && !includeTags.isEmpty()) {
+        request.filters(TagFilter.includeTags(includeTags.split(",")));
+      }
+
+      String excludeTags = System.getProperty("JUNIT5_EXCLUDE_TAGS");
+      if (excludeTags != null && !excludeTags.isEmpty()) {
+        request.filters(TagFilter.excludeTags(excludeTags.split(",")));
+      }
 
       File exitFile = getExitFile();
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//java:defs.bzl", "java_junit5_test", "junit5_deps")
+load("//java:defs.bzl", "java_junit5_test", "java_test_suite", "junit5_deps")
 
 java_junit5_test(
     name = "Junit5TagsTest_only_never",
@@ -32,6 +32,17 @@ java_junit5_test(
     srcs = ["Junit5TagsTest.java"],
     include_tags = ["Always"],
     test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.tags.Junit5TagsTest",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_test_suite(
+    name = "Junit5SuiteTest_only_always",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    include_tags = ["Always"],
+    runner = "junit5",
     deps = [
         artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
     ] + junit5_deps("contrib_rules_jvm_tests"),

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//java:defs.bzl", "java_junit5_test", "junit5_deps")
+
+java_junit5_test(
+    name = "Junit5TagsTest_only_never",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    exclude_tags = ["Never"],
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.tags.Junit5TagsTest",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_junit5_test(
+    name = "Junit5TagsTest_no_sometimes",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    exclude_tags = [
+        "Never",
+        "Sometimes",
+    ],
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.tags.Junit5TagsTest",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_junit5_test(
+    name = "Junit5TagsTest_only_always",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    include_tags = ["Always"],
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.tags.Junit5TagsTest",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/Junit5TagsTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/tags/Junit5TagsTest.java
@@ -1,0 +1,34 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5.tags;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class Junit5TagsTest {
+
+  @Test
+  @Tag("Always")
+  public void alwaysRun() {
+    assertTrue(true);
+  }
+
+  @Test
+  @Tag("Never")
+  public void neverRun() {
+    assertTrue(false);
+  }
+
+  @Test
+  @Tag("Sometimes")
+  public void runSometimes() {
+    // exclude shouldn't run
+    if (System.getProperty("JUNIT5_EXCLUDE_TAGS", "").contains("Sometimes")) {
+      assertTrue(false, "Should have skippend this test");
+    } else if (System.getProperty("JUNIT5_INCLUDE_TAGS", "").contains("Sometimes")) {
+      assertTrue(true, "Positive ask to run this test");
+    } else {
+      assertTrue(true, "Not specifically filtered, but run anyway");
+    }
+  }
+}


### PR DESCRIPTION
JUnit5 uses a `@Tag` annotation to allow users to construct specific lists of test, sometimes specific methods within a single class to run. This adds support for selecting tests to run in the JUnit5 Runner by setting and filtering by tags as requested.