### PR TITLE
More support for java test suites.

### DIFF
--- a/java/defs.bzl
+++ b/java/defs.bzl
@@ -4,6 +4,7 @@ load(
     _checkstyle_binary = "checkstyle_binary",
     _checkstyle_config = "checkstyle_config",
 )
+load("//java/private:create_jvm_test_suite.bzl", _create_jvm_test_suite = "create_jvm_test_suite")
 load("//java/private:java_test_suite.bzl", _java_test_suite = "java_test_suite")
 load(
     "//java/private:junit5.bzl",
@@ -32,6 +33,7 @@ load(
 checkstyle_binary = _checkstyle_binary
 checkstyle_config = _checkstyle_config
 checkstyle_test = _checkstyle_test
+create_jvm_test_suite = _create_jvm_test_suite
 java_binary = _java_binary
 java_export = _java_export
 java_library = _java_library

--- a/java/private/BUILD.bazel
+++ b/java/private/BUILD.bazel
@@ -51,6 +51,7 @@ bzl_library(
         ":pmd",
         ":spotbugs",
         "@apple_rules_lint//lint:implementation",
+        "@bazel_tools//tools/build_defs/repo:utils.bzl",
         "@rules_jvm_external//:implementation",
     ],
 )

--- a/java/private/library.bzl
+++ b/java/private/library.bzl
@@ -1,4 +1,5 @@
 load("@apple_rules_lint//lint:defs.bzl", "get_lint_config")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@rules_jvm_external//:defs.bzl", _java_export = "java_export")
 load("//java/private:checkstyle.bzl", "checkstyle_test")
 load("//java/private:pmd.bzl", "pmd_test")
@@ -13,8 +14,9 @@ def create_lint_tests(name, **kwargs):
     tags = kwargs.get("tags", [])
 
     checkstyle = get_lint_config("java-checkstyle", tags)
-    if checkstyle != None and not native.existing_rule("%s-checkstyle" % name):
-        checkstyle_test(
+    if checkstyle != None:
+        maybe(
+            checkstyle_test,
             name = "%s-checkstyle" % name,
             srcs = srcs,
             config = checkstyle,
@@ -25,8 +27,9 @@ def create_lint_tests(name, **kwargs):
         )
 
     pmd = get_lint_config("java-pmd", tags)
-    if pmd != None and not native.existing_rule("%s-pmd" % name):
-        pmd_test(
+    if pmd != None:
+        maybe(
+            pmd_test,
             name = "%s-pmd" % name,
             srcs = srcs,
             target = ":%s" % name,
@@ -37,8 +40,9 @@ def create_lint_tests(name, **kwargs):
         )
 
     spotbugs = get_lint_config("java-spotbugs", tags)
-    if spotbugs != None and not native.existing_rule("%s-spotbugs" % name):
-        spotbugs_test(
+    if spotbugs != None:
+        maybe(
+            spotbugs_test,
             name = "%s-spotbugs" % name,
             config = spotbugs,
             only_output_jars = True,

--- a/java/private/library.bzl
+++ b/java/private/library.bzl
@@ -37,7 +37,7 @@ def create_lint_tests(name, **kwargs):
         )
 
     spotbugs = get_lint_config("java-spotbugs", tags)
-    if spotbugs != None and not native.existing_rule("%s-spotbuts" % name):
+    if spotbugs != None and not native.existing_rule("%s-spotbugs" % name):
         spotbugs_test(
             name = "%s-spotbugs" % name,
             config = spotbugs,

--- a/java/private/library.bzl
+++ b/java/private/library.bzl
@@ -13,7 +13,7 @@ def create_lint_tests(name, **kwargs):
     tags = kwargs.get("tags", [])
 
     checkstyle = get_lint_config("java-checkstyle", tags)
-    if checkstyle != None:
+    if checkstyle != None and not native.existing_rule("%s-checkstyle" % name):
         checkstyle_test(
             name = "%s-checkstyle" % name,
             srcs = srcs,
@@ -25,7 +25,7 @@ def create_lint_tests(name, **kwargs):
         )
 
     pmd = get_lint_config("java-pmd", tags)
-    if pmd != None:
+    if pmd != None and not native.existing_rule("%s-pmd" % name):
         pmd_test(
             name = "%s-pmd" % name,
             srcs = srcs,
@@ -37,7 +37,7 @@ def create_lint_tests(name, **kwargs):
         )
 
     spotbugs = get_lint_config("java-spotbugs", tags)
-    if spotbugs != None:
+    if spotbugs != None and not native.existing_rule("%s-spotbuts" % name):
         spotbugs_test(
             name = "%s-spotbugs" % name,
             config = spotbugs,


### PR DESCRIPTION
This makes two changes to support further use of the Java Test suites matching what the junit5 testing allows. To that end there are two small changes here:
- expose the create_jvm_test_suite() macro to have access to set the define_test() for duplicate name processing.
- set the create_lint_tests() macro to avoid creating duplicate linter tests.