### PR TITLE
Identify fully-qualified types

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -239,7 +239,22 @@ public class ClasspathParser {
     }
 
     private boolean looksLikeClassName(String identifier) {
-      return identifier.length() > 0 && Character.isUpperCase(identifier.charAt(0));
+      if (identifier.isEmpty()) {
+        return false;
+      }
+      // Classes start with UpperCase.
+      if (!Character.isUpperCase(identifier.charAt(0))) {
+        return false;
+      }
+      // Single-char upper-case may well be a class-name.
+      if (identifier.length() == 1) {
+        return true;
+      }
+      // SNAKE_CASE is for constants not classes.
+      if (identifier.chars().allMatch(c -> Character.isUpperCase(c) || c == '_')) {
+        return false;
+      }
+      return true;
     }
 
     @Override

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -8,7 +8,11 @@ import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayTypeTree;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.source.tree.MethodInvocationTree;
+import com.sun.source.tree.NewClassTree;
 import com.sun.source.tree.PackageTree;
 import com.sun.source.tree.ParameterizedTypeTree;
 import com.sun.source.tree.PrimitiveTypeTree;
@@ -218,6 +222,38 @@ public class ClasspathParser {
         checkFullyQualifiedType(param.getType());
       }
       return super.visitMethod(m, v);
+    }
+
+    @Override
+    public Void visitMethodInvocation(MethodInvocationTree node, Void v) {
+      if (node.getMethodSelect() instanceof MemberSelectTree) {
+        ExpressionTree container = ((MemberSelectTree) node.getMethodSelect()).getExpression();
+        if (container instanceof MemberSelectTree) {
+          MemberSelectTree containerMST = (MemberSelectTree) container;
+          if (looksLikeClassName(containerMST.getIdentifier().toString())) {
+            checkFullyQualifiedType(container);
+          }
+        }
+      }
+      return super.visitMethodInvocation(node, v);
+    }
+
+    private boolean looksLikeClassName(String identifier) {
+      return identifier.length() > 0 && Character.isUpperCase(identifier.charAt(0));
+    }
+
+    @Override
+    public Void visitNewClass(NewClassTree node, Void v) {
+      checkFullyQualifiedType(node.getIdentifier());
+      return super.visitNewClass(node, v);
+    }
+
+    @Override
+    public Void visitVariable(VariableTree node, Void unused) {
+      if (node.getType() != null) {
+        checkFullyQualifiedType(node.getType());
+      }
+      return super.visitVariable(node, unused);
     }
 
     private void checkFullyQualifiedType(Tree identifier) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -226,6 +226,22 @@ public class ClasspathParserTest {
         parser.getAnnotatedClasses());
   }
 
+  @Test
+  public void testFullyQualifieds() throws IOException {
+    List<? extends JavaFileObject> files =
+            List.of(
+                    testFiles.get(
+                            "/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java"));
+    parser.parseClasses(files);
+
+    Set<String> expected = Set.of(
+            "workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest",
+            "workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse",
+            "workspace.com.gazelle.java.javaparser.utils.Printer",
+            "workspace.com.gazelle.java.javaparser.factories.Factory");
+    assertEquals(expected, parser.getUsedTypes());
+  }
+
   private <T> TreeSet<T> treeSet(T... values) {
     TreeSet<T> set = new TreeSet<>();
     for (T value : values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -229,12 +229,13 @@ public class ClasspathParserTest {
   @Test
   public void testFullyQualifieds() throws IOException {
     List<? extends JavaFileObject> files =
-            List.of(
-                    testFiles.get(
-                            "/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java"));
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java"));
     parser.parseClasses(files);
 
-    Set<String> expected = Set.of(
+    Set<String> expected =
+        Set.of(
             "workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest",
             "workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse",
             "workspace.com.gazelle.java.javaparser.utils.Printer",

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
@@ -1,19 +1,21 @@
 package workspace.com.gazelle.java.javaparser.generators;
 
 public class FullyQualifieds {
-    public void fn() {
-        new workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest();
-        workspace.com.gazelle.java.javaparser.utils.Printer.print();
+  public void fn() {
+    new workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest();
+    workspace.com.gazelle.java.javaparser.utils.Printer.print();
 
-        workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse response = workspace.com.gazelle.java.javaparser.factories.Factory.create();
+    workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse response =
+        workspace.com.gazelle.java.javaparser.factories.Factory.create();
 
-        // instance methods shouldn't get detected as classes (e.g. this.foo).
-        this.foo.bar();
+    // instance methods shouldn't get detected as classes (e.g. this.foo).
+    this.foo.bar();
 
-        // Anonymous variables in lambdas shouldn't be picked up as variable names - visitVariable sees them as variables with null types.
-        someList.map(x -> x.toString());
+    // Anonymous variables in lambdas shouldn't be picked up as variable names - visitVariable sees
+    // them as variables with null types.
+    someList.map(x -> x.toString());
 
-        this.BLAH = "beep";
-        this.BEEP_BOOP = "baz";
-    }
+    this.BLAH = "beep";
+    this.BEEP_BOOP = "baz";
+  }
 }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
@@ -1,0 +1,16 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+public class FullyQualifieds {
+    public void fn() {
+        new workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest();
+        workspace.com.gazelle.java.javaparser.utils.Printer.print();
+
+        workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse response = workspace.com.gazelle.java.javaparser.factories.Factory.create();
+
+        // instance methods shouldn't get detected as classes (e.g. this.foo).
+        this.foo.bar();
+
+        // Anonymous variables in lambdas shouldn't be picked up as variable names - visitVariable sees them as variables with null types.
+        someList.map(x -> x.toString());
+    }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
@@ -12,5 +12,8 @@ public class FullyQualifieds {
 
         // Anonymous variables in lambdas shouldn't be picked up as variable names - visitVariable sees them as variables with null types.
         someList.map(x -> x.toString());
+
+        this.BLAH = "beep";
+        this.BEEP_BOOP = "baz";
     }
 }


### PR DESCRIPTION
This adds three contexts where we look for fully qualified types:
* Fully-qualified static method calls
* Fully-qualified constructor calls
* Variable assignments with fully-qualified types

It's a bit heuristic - it guesses what's a type based on standard conventions of class names.