### PR TITLE
Gazelle flag to pass in maven_install path

### DIFF
--- a/java/gazelle/BUILD.bazel
+++ b/java/gazelle/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     name = "gazelle_test",
     size = "medium",
     srcs = [
+        "configure_test.go",
         "generate_test.go",
         "resolve_test.go",
     ],

--- a/java/gazelle/BUILD.bazel
+++ b/java/gazelle/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":gazelle"],
     deps = [
+        "//java/gazelle/javaconfig",
         "//java/gazelle/private/sorted_set",
         "@bazel_gazelle//config:go_default_library",
         "@bazel_gazelle//label:go_default_library",

--- a/java/gazelle/configure.go
+++ b/java/gazelle/configure.go
@@ -20,6 +20,7 @@ import (
 type Configurer struct {
 	lang                  *javaLang
 	annotationToAttribute annotationToAttribute
+	mavenInstallFile      string
 }
 
 func NewConfigurer(lang *javaLang) *Configurer {
@@ -31,6 +32,7 @@ func NewConfigurer(lang *javaLang) *Configurer {
 
 func (jc Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	fs.Var(&jc.annotationToAttribute, "java-annotation-to-attribute", "Mapping of annotations (on test classes) to attributes which should be set for that test rule. Examples: com.example.annotations.FlakyTest=flaky=True com.example.annotations.SlowTest=timeout=\"long\"")
+	fs.StringVar(&jc.mavenInstallFile, "java-maven-install-file", "", "Represents the directive that controls where the maven_install.json file is located. Defaults to \"maven_install.json\".")
 }
 
 func (jc *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
@@ -39,6 +41,9 @@ func (jc *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {
 		for k, v := range kv {
 			cfgs[""].MapAnnotationToAttribute(annotation, k, v)
 		}
+	}
+	if jc.mavenInstallFile != "" {
+		cfgs[""].SetMavenInstallFile(jc.mavenInstallFile)
 	}
 	return nil
 }

--- a/java/gazelle/configure.go
+++ b/java/gazelle/configure.go
@@ -30,9 +30,9 @@ func NewConfigurer(lang *javaLang) *Configurer {
 	}
 }
 
-func (jc Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
+func (jc *Configurer) RegisterFlags(fs *flag.FlagSet, cmd string, c *config.Config) {
 	fs.Var(&jc.annotationToAttribute, "java-annotation-to-attribute", "Mapping of annotations (on test classes) to attributes which should be set for that test rule. Examples: com.example.annotations.FlakyTest=flaky=True com.example.annotations.SlowTest=timeout=\"long\"")
-	fs.StringVar(&jc.mavenInstallFile, "java-maven-install-file", "", "Represents the directive that controls where the maven_install.json file is located. Defaults to \"maven_install.json\".")
+	fs.StringVar(&jc.mavenInstallFile, "java-maven-install-file", "", "Path of the maven_install.json file. Defaults to \"maven_install.json\".")
 }
 
 func (jc *Configurer) CheckFlags(fs *flag.FlagSet, c *config.Config) error {

--- a/java/gazelle/configure_test.go
+++ b/java/gazelle/configure_test.go
@@ -1,0 +1,30 @@
+package gazelle
+
+import (
+	"testing"
+
+	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
+	"github.com/bazelbuild/bazel-gazelle/config"
+	"github.com/bazelbuild/bazel-gazelle/language"
+	"github.com/bazelbuild/bazel-gazelle/testtools"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFlagParsing(t *testing.T) {
+	configurer := NewConfigurer(NewLanguage().(*javaLang))
+
+	gazelleConfig := testtools.NewTestConfig(t,
+		[]config.Configurer{configurer},
+		[]language.Language{},
+		[]string{
+			"-java-annotation-to-attribute=com.example.annotations.FlakyTest=flaky=True",
+			"-java-maven-install-file=install_maven.json",
+		})
+
+	// Command line value made it to the configurer
+	require.Equal(t, "install_maven.json", configurer.mavenInstallFile)
+
+	// Command line value made it to the java config
+	javaConfig := gazelleConfig.Exts[languageName].(javaconfig.Configs)
+	require.Equal(t, "install_maven.json", javaConfig[""].MavenInstallFile())
+}


### PR DESCRIPTION
Fixes https://github.com/bazel-contrib/rules_jvm/issues/129

Adds a command line flag to gazelle (`java-maven-install-file`) to set the maven install file path.