### PR TITLE
javaparser returns classes and packages separately

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -187,7 +187,8 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			allPackageNames.Add(mJavaPkg.Name)
 
 			if !mJavaPkg.TestPackage {
-				addNonLocalImports(productionJavaImports, mJavaPkg.Imports, mJavaPkg.Name, javaClassNamesFromFileNames)
+				addNonLocalImports(productionJavaImports, mJavaPkg.ImportedClasses, mJavaPkg.Name, javaClassNamesFromFileNames)
+				addNonLocalImports(productionJavaImports, mJavaPkg.ImportedPackagesWithoutSpecificClasses, mJavaPkg.Name, javaClassNamesFromFileNames)
 				for _, f := range mJavaPkg.Files.SortedSlice() {
 					productionJavaFiles.Add(filepath.Join(mRel, f))
 				}
@@ -198,7 +199,8 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 					})
 				}
 			} else {
-				addNonLocalImports(testJavaImports, mJavaPkg.Imports, mJavaPkg.Name, javaClassNamesFromFileNames)
+				addNonLocalImports(testJavaImports, mJavaPkg.ImportedClasses, mJavaPkg.Name, javaClassNamesFromFileNames)
+				addNonLocalImports(testJavaImports, mJavaPkg.ImportedPackagesWithoutSpecificClasses, mJavaPkg.Name, javaClassNamesFromFileNames)
 				for _, f := range mJavaPkg.Files.SortedSlice() {
 					path := filepath.Join(mRel, f)
 					file := javaFile{
@@ -212,9 +214,11 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	} else {
 		allPackageNames.Add(javaPkg.Name)
 		if javaPkg.TestPackage {
-			addNonLocalImports(testJavaImports, javaPkg.Imports, javaPkg.Name, javaClassNamesFromFileNames)
+			addNonLocalImports(testJavaImports, javaPkg.ImportedClasses, javaPkg.Name, javaClassNamesFromFileNames)
+			addNonLocalImports(testJavaImports, javaPkg.ImportedPackagesWithoutSpecificClasses, javaPkg.Name, javaClassNamesFromFileNames)
 		} else {
-			addNonLocalImports(productionJavaImports, javaPkg.Imports, javaPkg.Name, javaClassNamesFromFileNames)
+			addNonLocalImports(productionJavaImports, javaPkg.ImportedClasses, javaPkg.Name, javaClassNamesFromFileNames)
+			addNonLocalImports(productionJavaImports, javaPkg.ImportedPackagesWithoutSpecificClasses, javaPkg.Name, javaClassNamesFromFileNames)
 		}
 		for _, mainClassName := range javaPkg.Mains.SortedSlice() {
 			allMains = append(allMains, main{

--- a/java/gazelle/private/java/package.go
+++ b/java/gazelle/private/java/package.go
@@ -5,8 +5,9 @@ import "github.com/bazel-contrib/rules_jvm/java/gazelle/private/sorted_set"
 type Package struct {
 	Name string
 
-	Imports *sorted_set.SortedSet[string]
-	Mains   *sorted_set.SortedSet[string]
+	ImportedClasses                        *sorted_set.SortedSet[string]
+	ImportedPackagesWithoutSpecificClasses *sorted_set.SortedSet[string]
+	Mains                                  *sorted_set.SortedSet[string]
 
 	// Especially useful for module mode
 	Files       *sorted_set.SortedSet[string]

--- a/java/gazelle/private/javaparser/javaparser.go
+++ b/java/gazelle/private/javaparser/javaparser.go
@@ -64,11 +64,12 @@ func (r Runner) ParsePackage(ctx context.Context, in *ParsePackageRequest) (*jav
 	}
 
 	return &java.Package{
-		Name:             resp.GetName(),
-		Imports:          sorted_set.NewSortedSet(resp.GetImports()),
-		Mains:            sorted_set.NewSortedSet(resp.GetMains()),
-		Files:            sorted_set.NewSortedSet(in.Files),
-		TestPackage:      java.IsTestPath(in.Rel),
-		PerClassMetadata: perClassMetadata,
+		Name:                                   resp.GetName(),
+		ImportedClasses:                        sorted_set.NewSortedSet(resp.GetImportedClasses()),
+		ImportedPackagesWithoutSpecificClasses: sorted_set.NewSortedSet(resp.GetImportedPackagesWithoutSpecificClasses()),
+		Mains:                                  sorted_set.NewSortedSet(resp.GetMains()),
+		Files:                                  sorted_set.NewSortedSet(in.Files),
+		TestPackage:                            java.IsTestPath(in.Rel),
+		PerClassMetadata:                       perClassMetadata,
 	}, nil
 }

--- a/java/gazelle/private/javaparser/proto/gazelle/java/javaparser/v0/javaparser.proto
+++ b/java/gazelle/private/javaparser/proto/gazelle/java/javaparser/v0/javaparser.proto
@@ -29,13 +29,15 @@ message Package {
   // Example: "com.a.b"
   string name = 1;
 
-  // The list of imported class/functions in the requests files.
+  // The list of classes in the request's files which are either imported or referenced by fully-qualified type.
   //
   // Deduplicated on the import string.
-  // Java standard library imports are filtered out.
   //
-  // Example: ["org.junit.Assert.assertEquals", "org.junit.Test"]
-  repeated string imports = 2;
+  // Example: ["java.util.ArrayList", "org.junit.Test"]
+  repeated string imported_classes = 2;
+
+  // As imports except with imported package names which didn't have specific classes imported (i.e. that were wildcard imports).
+  repeated string imported_packages_without_specific_classes = 5;
 
   // Class names in the package with a main function.
   //

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -44,6 +44,7 @@ public class ClasspathParser {
   private static final Logger logger = LoggerFactory.getLogger(ClasspathParser.class);
 
   private final Set<String> usedTypes = new TreeSet<>();
+  private final Set<String> usedPackagesWithoutSpecificTypes = new TreeSet<>();
   private final Set<String> packages = new TreeSet<>();
   private final Set<String> mainClasses = new TreeSet<>();
 
@@ -61,6 +62,10 @@ public class ClasspathParser {
 
   public Set<String> getUsedTypes() {
     return usedTypes;
+  }
+
+  public Set<String> getUsedPackagesWithoutSpecificTypes() {
+    return usedPackagesWithoutSpecificTypes;
   }
 
   public Set<String> getPackages() {
@@ -160,9 +165,9 @@ public class ClasspathParser {
       if (i.isStatic()) {
         String staticPackage = name.substring(0, name.lastIndexOf('.'));
         usedTypes.add(staticPackage);
-      } else if (name.endsWith("*")) {
+      } else if (name.endsWith(".*")) {
         String wildcardPackage = name.substring(0, name.lastIndexOf('.'));
-        usedTypes.add(wildcardPackage);
+        usedPackagesWithoutSpecificTypes.add(wildcardPackage);
       } else {
         String[] parts = i.getQualifiedIdentifier().toString().split("\\.");
         currentFileImports.put(parts[parts.length - 1], i.getQualifiedIdentifier().toString());

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -3,6 +3,9 @@ package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Lists;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayTypeTree;
@@ -60,24 +63,29 @@ public class ClasspathParser {
     // Doesn't need to do anything currently
   }
 
-  public Set<String> getUsedTypes() {
-    return usedTypes;
+  public ImmutableSet<String> getUsedTypes() {
+    return ImmutableSet.copyOf(usedTypes);
   }
 
-  public Set<String> getUsedPackagesWithoutSpecificTypes() {
-    return usedPackagesWithoutSpecificTypes;
+  public ImmutableSet<String> getUsedPackagesWithoutSpecificTypes() {
+    return ImmutableSet.copyOf(usedPackagesWithoutSpecificTypes);
   }
 
-  public Set<String> getPackages() {
-    return packages;
+  public ImmutableSet<String> getPackages() {
+    return ImmutableSet.copyOf(packages);
   }
 
-  public Set<String> getMainClasses() {
-    return mainClasses;
+  public ImmutableSet<String> getMainClasses() {
+    return ImmutableSet.copyOf(mainClasses);
   }
 
-  public Map<String, SortedSet<String>> getAnnotatedClasses() {
-    return annotatedClasses;
+  public ImmutableMap<String, ImmutableSortedSet<String>> getAnnotatedClasses() {
+    ImmutableMap.Builder<String, ImmutableSortedSet<String>> builder =
+        ImmutableMap.builderWithExpectedSize(annotatedClasses.size());
+    for (Map.Entry<String, SortedSet<String>> entry : annotatedClasses.entrySet()) {
+      builder.put(entry.getKey(), ImmutableSortedSet.copyOf(entry.getValue()));
+    }
+    return builder.build();
   }
 
   public void parseClasses(Path directory, List<String> files) throws IOException {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/GrpcServer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/GrpcServer.java
@@ -143,11 +143,16 @@ public class GrpcServer {
       }
       logger.debug("Got package: {}", Iterables.getOnlyElement(packages));
       logger.debug("Got used types: {}", parser.getUsedTypes());
+      logger.debug(
+          "Got used packages without specific types: {}",
+          parser.getUsedPackagesWithoutSpecificTypes());
 
       Builder packageBuilder =
           Package.newBuilder()
               .setName(Iterables.getOnlyElement(packages))
-              .addAllImports(parser.getUsedTypes())
+              .addAllImportedClasses(parser.getUsedTypes())
+              .addAllImportedPackagesWithoutSpecificClasses(
+                  parser.getUsedPackagesWithoutSpecificTypes())
               .addAllMains(parser.getMainClasses());
       for (Map.Entry<String, SortedSet<String>> annotations :
           parser.getAnnotatedClasses().entrySet()) {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/GrpcServer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/GrpcServer.java
@@ -7,6 +7,8 @@ import com.gazelle.java.javaparser.v0.Package;
 import com.gazelle.java.javaparser.v0.Package.Builder;
 import com.gazelle.java.javaparser.v0.ParsePackageRequest;
 import com.gazelle.java.javaparser.v0.PerClassMetadata;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
 import com.google.common.collect.Iterables;
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
@@ -23,7 +25,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.SortedSet;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,7 +140,7 @@ public class GrpcServer {
       } else if (packages.isEmpty()) {
         logger.info(
             "Set of classes in {} has no package", Paths.get(request.getRel()).toAbsolutePath());
-        packages.add("");
+        packages = ImmutableSet.of("");
       }
       logger.debug("Got package: {}", Iterables.getOnlyElement(packages));
       logger.debug("Got used types: {}", parser.getUsedTypes());
@@ -154,7 +155,7 @@ public class GrpcServer {
               .addAllImportedPackagesWithoutSpecificClasses(
                   parser.getUsedPackagesWithoutSpecificTypes())
               .addAllMains(parser.getMainClasses());
-      for (Map.Entry<String, SortedSet<String>> annotations :
+      for (Map.Entry<String, ImmutableSortedSet<String>> annotations :
           parser.getAnnotatedClasses().entrySet()) {
         packageBuilder.putPerClassMetadata(
             annotations.getKey(),

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -140,8 +140,8 @@ public class ClasspathParserTest {
     List<? extends JavaFileObject> files =
         List.of(testFiles.get("/workspace/com/gazelle/java/javaparser/generators/Wildcards.java"));
     parser.parseClasses(files);
-    assertEquals(
-        Set.of("org.junit.jupiter.api", "org.junit.jupiter.api.Assertions"), parser.getUsedTypes());
+    assertEquals(Set.of("org.junit.jupiter.api.Assertions"), parser.getUsedTypes());
+    assertEquals(Set.of("org.junit.jupiter.api"), parser.getUsedPackagesWithoutSpecificTypes());
   }
 
   @Test
@@ -175,7 +175,9 @@ public class ClasspathParserTest {
             testFiles.get("/workspace/com/gazelle/java/javaparser/generators/WildcardImport.java"));
     parser.parseClasses(files);
 
-    assertEquals(Set.of("com.google.common.primitives"), parser.getUsedTypes());
+    assertEquals(Set.of(), parser.getUsedTypes());
+    assertEquals(
+        Set.of("com.google.common.primitives"), parser.getUsedPackagesWithoutSpecificTypes());
   }
 
   @Test
@@ -240,7 +242,8 @@ public class ClasspathParserTest {
             "workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest",
             "workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse",
             "workspace.com.gazelle.java.javaparser.utils.Printer",
-            "workspace.com.gazelle.java.javaparser.factories.Factory");
+            "workspace.com.gazelle.java.javaparser.factories.Factory",
+            "java.util.ArrayList");
     assertEquals(expected, parser.getUsedTypes());
   }
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FullyQualifieds.java
@@ -15,6 +15,8 @@ public class FullyQualifieds {
     // them as variables with null types.
     someList.map(x -> x.toString());
 
+    new java.util.ArrayList<String>().stream().map(y -> y.toString());
+
     this.BLAH = "beep";
     this.BEEP_BOOP = "baz";
   }


### PR DESCRIPTION
Previously, some of the values in imports were classes and others were
packages. This makes handling them on the client side more fiddly.
Instead, differentiate between the two where we know which we're
handling.

Also, fix up some tests and documentation which were obsolete,
clarifying that we don't strip standard library types here any more,
this is now done on the client side.

I'm about to introduce much stronger typed handling of classes vs
packages in the Go code, so the ugly "double-call addNonLocalImports"
pattern will go away shortly.