### PR TITLE
Convert junit5 tests to be pure junit5

### DIFF
--- a/java/gazelle/testdata/module-granularity/module1/BUILD.out
+++ b/java/gazelle/testdata/module-granularity/module1/BUILD.out
@@ -34,7 +34,6 @@ java_test_suite(
     ],
     deps = [
         ":module1",
-        "@maven//:junit_junit",
         "@maven//:org_hamcrest_hamcrest_all",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],

--- a/java/gazelle/testdata/module-granularity/module1/src/test/java/com/example/hello/world/WorldTest.java
+++ b/java/gazelle/testdata/module-granularity/module1/src/test/java/com/example/hello/world/WorldTest.java
@@ -1,6 +1,6 @@
 package com.example.hello.world;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/BUILD.out
+++ b/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/BUILD.out
@@ -11,7 +11,6 @@ java_test_suite(
     ],
     deps = [
         "//notmodule/src/main/java/com/example/hello/notworld",
-        "@maven//:junit_junit",
         "@maven//:org_junit_jupiter_junit_jupiter_api",
     ],
 )

--- a/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/NotWorldTest.java
+++ b/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/NotWorldTest.java
@@ -1,6 +1,6 @@
 package com.example.hello.notworld;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 

--- a/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/withhelpers/BUILD.out
+++ b/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/withhelpers/BUILD.out
@@ -12,8 +12,5 @@ java_test_suite(
         "@maven//:org_junit_platform_junit_platform_launcher",
         "@maven//:org_junit_platform_junit_platform_reporting",
     ],
-    deps = [
-        "@maven//:junit_junit",
-        "@maven//:org_junit_jupiter_junit_jupiter_api",
-    ],
+    deps = ["@maven//:org_junit_jupiter_junit_jupiter_api"],
 )

--- a/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/withhelpers/NotWorldWithHelpersTest.java
+++ b/java/gazelle/testdata/module-granularity/notmodule/src/test/java/com/example/hello/notworld/withhelpers/NotWorldWithHelpersTest.java
@@ -1,6 +1,6 @@
 package com.example.hello.hello.notworld.withhelpers;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Right now we're detecting both junit4 and junit5 features of these tests, because we're using Assert from junit4.

Instead, make these tests pure junit5. We have specific tests for testing junit4/junit5/mixed behaviour.