### PR TITLE
Ignore inner classes' empty packages

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -349,16 +349,16 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 func addNonLocalImports(to *sorted_set.SortedSet[string], from *sorted_set.SortedSet[string], pkg string, localClasses *sorted_set.SortedSet[string]) {
 	for _, impString := range from.SortedSlice() {
 		imp := java.NewImport(impString)
-		doAdd := true
 		if pkg == imp.Pkg {
 			if localClasses.Contains(imp.Classes[0]) {
-				doAdd = false
+				continue
 			}
 		}
-
-		if doAdd {
-			to.Add(impString)
+		if imp.Pkg == "" {
+			continue
 		}
+
+		to.Add(impString)
 	}
 }
 

--- a/java/gazelle/testdata/inner_classes/expectedStderr.txt
+++ b/java/gazelle/testdata/inner_classes/expectedStderr.txt
@@ -1,0 +1,1 @@
+[90m12:00AM[0m [31mWRN[0m [1mjava/gazelle/private/maven/resolver.go:XXX[0m[36m >[0m not loading maven dependencies [36merror=[0m[31m"open %WORKSPACEPATH%/maven_install.json: no such file or directory"[0m [36m_c=[0mmaven-resolver

--- a/java/gazelle/testdata/inner_classes/src/main/com/example/package1/BUILD.out
+++ b/java/gazelle/testdata/inner_classes/src/main/com/example/package1/BUILD.out
@@ -1,0 +1,7 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "package1",
+    srcs = ["ClassWithInnerClass.java"],
+    visibility = ["//:__subpackages__"],
+)

--- a/java/gazelle/testdata/inner_classes/src/main/com/example/package1/ClassWithInnerClass.java
+++ b/java/gazelle/testdata/inner_classes/src/main/com/example/package1/ClassWithInnerClass.java
@@ -1,0 +1,9 @@
+package com.example.package1;
+
+public class ClassWithInnerClass {
+    public static class InnerClass {
+        public String getMessage() {
+            return "Woo!";
+        }
+    }
+}

--- a/java/gazelle/testdata/inner_classes/src/main/com/example/package2/BUILD.out
+++ b/java/gazelle/testdata/inner_classes/src/main/com/example/package2/BUILD.out
@@ -1,0 +1,8 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "package2",
+    srcs = ["Caller.java"],
+    visibility = ["//:__subpackages__"],
+    deps = ["//src/main/com/example/package1"],
+)

--- a/java/gazelle/testdata/inner_classes/src/main/com/example/package2/Caller.java
+++ b/java/gazelle/testdata/inner_classes/src/main/com/example/package2/Caller.java
@@ -1,0 +1,10 @@
+package com.example.package2;
+
+import com.example.package1.ClassWithInnerClasses;
+
+public class Caller {
+    public void doCall() {
+        ClassWithInnerClass.InnerClass innerClass = new ClassWithInnerClass.InnerClass();
+        System.out.println(innerClass.getMessage());
+    }
+}


### PR DESCRIPTION
Before this change, we add a lot of logspam when inner classes are used because we detect classes in empty packages.

Instead, don't try to resolve empty packages as dependencies.