### PR TITLE
Simplify testdata lookup

### DIFF
--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -14,7 +14,7 @@ java_test_suite(
     ],
     resource_strip_prefix = "java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators",
     resources = [
-        "java-test-workspace",
+        ":java-test-workspace",
     ],
     runner = "junit5",
     runtime_deps = [


### PR DESCRIPTION
The JavaSource constructor used to require two (incorrectly named) equivalent arguments. Now it just requires one.

Also, throw on failure to read, rather than treating the file as empty - we want to proactively fail the test if we can't read one of the testdata files.