### PR TITLE
Ensure that sysout and syserr are escaped

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestResult.java
@@ -109,14 +109,14 @@ class TestResult extends BaseResult {
           String stdout = getStdOut();
           if (stdout != null) {
             xml.writeStartElement("system-out");
-            xml.writeCData(stdout);
+            xml.writeCData(escapeIllegalCharacters(stdout));
             xml.writeEndElement();
           }
 
           String stderr = getStdErr();
           if (stderr != null) {
             xml.writeStartElement("system-err");
-            xml.writeCData(stderr);
+            xml.writeCData(escapeIllegalCharacters(stderr));
             xml.writeEndElement();
           }
 


### PR DESCRIPTION
Sadly, the IJ console won't unescape the content, but this is a definite step forwards.