### PR TITLE
Use TestExecutionListener in shard test

### DIFF
--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/ShardingTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/ShardingTest.java
@@ -4,55 +4,74 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.github.bazel_contrib.contrib_rules_jvm.junit5.sample.ShardingTestMoreTests;
 import com.github.bazel_contrib.contrib_rules_jvm.junit5.sample.ShardingTestTests;
+import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.LauncherDiscoveryRequest;
 import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
 import org.junit.platform.launcher.TestIdentifier;
-import org.junit.platform.launcher.TestPlan;
+import org.junit.platform.launcher.core.LauncherConfig;
 import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
 import org.junit.platform.launcher.core.LauncherFactory;
 
 public class ShardingTest {
 
+  private static final UniqueId ENGINE_ID = UniqueId.forEngine("junit-jupiter");
   private static final UniqueId SHARDING_TEST_TESTS =
-      UniqueId.forEngine("junit-jupiter").append("class", ShardingTestTests.class.getName());
+      ENGINE_ID.append("class", ShardingTestTests.class.getName());
   private static final UniqueId SHARDING_TEST_MORE_TESTS =
-      UniqueId.forEngine("junit-jupiter").append("class", ShardingTestMoreTests.class.getName());
+      ENGINE_ID.append("class", ShardingTestMoreTests.class.getName());
 
   private Set<UniqueId> tests;
 
   @Before
   public void setUp() {
-    PostDiscoveryFilter shardFilter = TestSharding.makeShardFilter();
     LauncherDiscoveryRequest request =
         LauncherDiscoveryRequestBuilder.request()
             .selectors(
                 DiscoverySelectors.selectPackage(
                     ShardingTest.class.getPackage().getName() + ".sample"))
-            .filters(shardFilter)
             .build();
-    TestPlan testPlan = LauncherFactory.create().discover(request);
-    tests =
-        testPlan.getRoots().stream()
-            .flatMap(root -> testPlan.getDescendants(root).stream())
-            .map(TestIdentifier::getUniqueIdObject)
-            .collect(Collectors.toSet());
+
+    tests = new HashSet<>();
+    PostDiscoveryFilter shardFilter = TestSharding.makeShardFilter();
+    LauncherConfig config =
+        LauncherConfig.builder()
+            .addTestExecutionListeners(
+                new TestExecutionListener() {
+                  @Override
+                  public void executionStarted(TestIdentifier testIdentifier) {
+                    tests.add(testIdentifier.getUniqueIdObject());
+                  }
+                })
+            .addPostDiscoveryFilters(shardFilter)
+            .build();
+
+    LauncherFactory.create(config).execute(request);
   }
 
   @Test
   public void testShard1() {
     assertEquals(
         Set.of(
+            ENGINE_ID,
             SHARDING_TEST_TESTS,
             test(SHARDING_TEST_TESTS, "testSeven"),
             SHARDING_TEST_MORE_TESTS,
             test(SHARDING_TEST_MORE_TESTS, "testTwo"),
-            testTemplate(SHARDING_TEST_MORE_TESTS, "testParameterized", "int")),
+            testTemplate(SHARDING_TEST_MORE_TESTS, "testParameterized", "int"),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 1),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 2),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 3),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 4),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 5),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 6),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 7),
+            testTemplateInvocation(SHARDING_TEST_MORE_TESTS, "testParameterized", "int", 8)),
         tests);
   }
 
@@ -60,6 +79,7 @@ public class ShardingTest {
   public void testShard2() {
     assertEquals(
         Set.of(
+            ENGINE_ID,
             SHARDING_TEST_TESTS,
             test(SHARDING_TEST_TESTS, "testOne"),
             test(SHARDING_TEST_TESTS, "testThree"),
@@ -75,6 +95,7 @@ public class ShardingTest {
   public void testShard3() {
     assertEquals(
         Set.of(
+            ENGINE_ID,
             SHARDING_TEST_TESTS,
             test(SHARDING_TEST_TESTS, "testEight"),
             SHARDING_TEST_MORE_TESTS,
@@ -90,10 +111,27 @@ public class ShardingTest {
   public void testShard4() {
     assertEquals(
         Set.of(
+            ENGINE_ID,
             SHARDING_TEST_TESTS,
             test(SHARDING_TEST_TESTS, "testTwo"),
             testTemplate(
                 SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo"),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 1),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 2),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 3),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 4),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 5),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 6),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 7),
+            testTemplateInvocation(
+                SHARDING_TEST_TESTS, "testRepeated", "org.junit.jupiter.api.RepetitionInfo", 8),
             SHARDING_TEST_MORE_TESTS,
             test(SHARDING_TEST_MORE_TESTS, "testEight")),
         tests);
@@ -105,5 +143,11 @@ public class ShardingTest {
 
   private UniqueId testTemplate(UniqueId classId, String testName, String testArgs) {
     return classId.append("test-template", testName + "(" + testArgs + ")");
+  }
+
+  private UniqueId testTemplateInvocation(
+      UniqueId classId, String testName, String testArgs, int invocation) {
+    return testTemplate(classId, testName, testArgs)
+        .append("test-template-invocation", "#" + invocation);
   }
 }


### PR DESCRIPTION
Makes the test slightly more realistic and is needed for future work on sharding parameterized tests.