### PR TITLE
Expand on the ability to include the same test in two suites

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -57,7 +57,7 @@ def create_jvm_test_suite(
         calculated from the bazel package.
       library_attributes: Attributes to pass to `define_library`.
       define_library: A function that creates a `*_library` target.
-      define_test: A function that creates a `*_test` target and returns the name of the test.
+      define_test: A function that creates a `*_test` target and returns the name of the created target.
         (See java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags for example use)
       runner: The junit runner to use. Either "junit4" or "junit5".
       deps: The list of dependencies to use when compiling.

--- a/java/private/java_test_suite.bzl
+++ b/java/private/java_test_suite.bzl
@@ -7,13 +7,6 @@ load(":junit5.bzl", "java_junit5_test")
 # The key thing that this file adds is the ability to specify a
 # suite of java tests by just globbing the test files.
 
-_LIBRARY_ATTRS = [
-    "data",
-    "javacopts",
-    "plugins",
-    "resources",
-]
-
 def _define_library(name, **kwargs):
     java_library(
         name = name,
@@ -25,6 +18,7 @@ def _define_junit4_test(name, **kwargs):
         name = name,
         **kwargs
     )
+    return name
 
 def _define_junit5_test(name, **kwargs):
     java_junit5_test(
@@ -33,6 +27,7 @@ def _define_junit5_test(name, **kwargs):
         exclude_engines = kwargs.pop("exclude_engines", None),
         **kwargs
     )
+    return name
 
 # Note: the keys in this match the keys in `create_jvm_test_suite.bzl`'s
 # `_RUNNERS` constant
@@ -83,7 +78,6 @@ def java_test_suite(
         srcs = srcs,
         test_suffixes = test_suffixes,
         package = package,
-        library_attributes = _LIBRARY_ATTRS,
         define_library = _define_library,
         # Default to bazel's default test runner if we don't know what people want
         define_test = _TEST_GENERATORS.get(runner, _define_junit4_test),

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/BUILD.bazel
@@ -1,0 +1,36 @@
+load("@rules_jvm_external//:defs.bzl", "artifact")
+load("//java:defs.bzl", "junit5_deps")
+load(":java_test_suite.bzl", "java_test_suite")
+
+java_test_suite(
+    name = "Junit5TagsTest_only_never",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    exclude_tags = ["Never"],
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_test_suite(
+    name = "Junit5TagsTest_no_sometimes",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    exclude_tags = [
+        "Never",
+        "Sometimes",
+    ],
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_test_suite(
+    name = "Junit5TagsTest_only_always",
+    size = "small",
+    srcs = ["Junit5TagsTest.java"],
+    include_tags = ["Always"],
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/Junit5TagsTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/Junit5TagsTest.java
@@ -1,0 +1,34 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5.suite_tags;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+public class Junit5TagsTest {
+
+  @Test
+  @Tag("Always")
+  public void alwaysRun() {
+    assertTrue(true);
+  }
+
+  @Test
+  @Tag("Never")
+  public void neverRun() {
+    assertTrue(false);
+  }
+
+  @Test
+  @Tag("Sometimes")
+  public void runSometimes() {
+    // exclude shouldn't run
+    if (System.getProperty("JUNIT5_EXCLUDE_TAGS", "").contains("Sometimes")) {
+      assertTrue(false, "Should have skippend this test");
+    } else if (System.getProperty("JUNIT5_INCLUDE_TAGS", "").contains("Sometimes")) {
+      assertTrue(true, "Positive ask to run this test");
+    } else {
+      assertTrue(true, "Not specifically filtered, but run anyway");
+    }
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/java_test_suite.bzl
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/java_test_suite.bzl
@@ -1,0 +1,35 @@
+load("//java:defs.bzl", "java_junit5_test", "java_library", test_suite = "create_jvm_test_suite")
+
+def _define_junit5_test(name, **kwargs):
+    duplicate_test_name = kwargs.pop("duplicate_test_name", None)
+
+    test_name = "%s-%s" % (duplicate_test_name, name) if duplicate_test_name else name
+    java_junit5_test(
+        name = test_name,
+        **kwargs
+    )
+
+    return test_name
+
+def _define_library(name, **kwargs):
+    java_library(
+        name = name,
+        **kwargs
+    )
+
+def java_test_suite(
+        name,
+        runner = "junit5",
+        test_suffixes = ["Test.java"],
+        package = None,
+        **kwargs):
+    test_suite(
+        name,
+        test_suffixes = test_suffixes,
+        package = package,
+        define_test = _define_junit5_test,
+        define_library = _define_library,
+        runner = runner,
+        duplicate_test_name = name,
+        **kwargs
+    )


### PR DESCRIPTION
This is to expand the ability of the user to create their own "define_test()" to allow non-default behavior for creating tests within the suite. The goal for this was to add the same test class to two different suites and run them with different configurations.

Add documentation about expected use of the define_test() macro