### PR TITLE
Don't tag builds as prereleases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
-          prerelease: true
+          prerelease: false
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt


### PR DESCRIPTION
We don't actually do prereleases in this repo.