### PR TITLE
Support parallel test execution in the JUnit5 runner

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
@@ -1,17 +1,19 @@
 package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
 
 import java.io.BufferedWriter;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -50,7 +52,8 @@ public class BazelJUnitOutputListener implements TestExecutionListener, Closeabl
     roots =
         testPlan.getRoots().stream()
             .map(root -> new RootContainer(root, testPlan))
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+            .collect(
+                collectingAndThen(toCollection(LinkedHashSet::new), Collections::unmodifiableSet));
   }
 
   @Override

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/CloseableReadWriteLock.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/CloseableReadWriteLock.java
@@ -1,0 +1,22 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+public class CloseableReadWriteLock {
+  private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+
+  public interface SilentAutoCloseable extends AutoCloseable {
+    @Override
+    void close();
+  }
+
+  public SilentAutoCloseable readLock() {
+    lock.readLock().lock();
+    return lock.readLock()::unlock;
+  }
+
+  public SilentAutoCloseable writeLock() {
+    lock.writeLock().lock();
+    return lock.writeLock()::unlock;
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/RootContainer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/RootContainer.java
@@ -1,5 +1,9 @@
 package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
+
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -12,14 +16,18 @@ import org.junit.platform.launcher.TestPlan;
 public class RootContainer extends BaseResult {
 
   // Insertion order matters when we come to output the results
-  private final List<TestSuiteResult> suites = new LinkedList<>();
+  private final List<TestSuiteResult> suites;
   private final TestPlan testPlan;
 
   public RootContainer(TestIdentifier rootId, TestPlan testPlan) {
     super(rootId);
     this.testPlan = testPlan;
 
-    testPlan.getChildren(rootId).forEach(child -> suites.add(createSuite(child)));
+    suites =
+        testPlan.getChildren(rootId).stream()
+            .map(this::createSuite)
+            .collect(
+                collectingAndThen(toCollection(LinkedList::new), Collections::unmodifiableList));
   }
 
   public void addDynamicTest(TestIdentifier testIdentifier) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -1,11 +1,15 @@
 load("@rules_jvm_external//:defs.bzl", "artifact")
-load("//java:defs.bzl", "java_test_suite", "junit5_deps", "junit5_vintage_deps")
+load("//java:defs.bzl", "java_junit5_test", "java_test_suite", "junit5_deps", "junit5_vintage_deps")
 
 # Ignore this directory because of the wrong package name.
 # gazelle:ignore
 
 PACKAGE_NAME_TEST = [
     "WrongPackageNameTest.java",
+]
+
+PARALLEL_TEST = [
+    "ParallelTest.java",
 ]
 
 SHARDING_TEST = [
@@ -17,7 +21,7 @@ java_test_suite(
     size = "small",
     srcs = glob(
         ["*.java"],
-        exclude = PACKAGE_NAME_TEST + SHARDING_TEST,
+        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST,
     ),
     exclude_engines = ["junit-vintage"],
     include_engines = ["junit-jupiter"],
@@ -56,6 +60,25 @@ java_test(
     deps = [
         "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
         "//java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample:sharding-test-tests",
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+        artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_junit5_test(
+    name = "parallel-test",
+    size = "small",
+    srcs = PARALLEL_TEST,
+    jvm_flags = [
+        "-Djunit.jupiter.execution.parallel.enabled=true",
+        "-Djunit.jupiter.execution.parallel.mode.default=concurrent",
+        "-Djunit.jupiter.execution.parallel.config.strategy=fixed",
+        "-Djunit.jupiter.execution.parallel.config.fixed.parallelism=2",
+    ],
+    tags = ["cpu:2"],
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.ParallelTest",
+    deps = [
+        "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
         artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
         artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
     ] + junit5_deps("contrib_rules_jvm_tests"),

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/ParallelTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/ParallelTest.java
@@ -1,0 +1,64 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.RepeatedTest;
+
+/**
+ * Verifies that {@link BazelJUnitOutputListener} does not throw any exceptions during parallel test
+ * execution (in particular, no {@link java.util.ConcurrentModificationException} by asserting that
+ * JUnit logs no warnings - every exception thrown by a {@link
+ * org.junit.platform.launcher.TestExecutionListener} results in one.
+ */
+public class ParallelTest {
+
+  private static LogHandler logHandler;
+
+  public static class LogHandler extends Handler {
+
+    Set<LogRecord> warnings = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    @Override
+    public void publish(LogRecord logRecord) {
+      if (logRecord.getLevel().intValue() >= Level.WARNING.intValue()) {
+        warnings.add(logRecord);
+      }
+    }
+
+    public void assertNoWarnings() {
+      assertEquals(
+          Collections.emptyList(),
+          warnings.stream().map(LogRecord::getMessage).collect(Collectors.toList()));
+    }
+
+    @Override
+    public void flush() {}
+
+    @Override
+    public void close() throws SecurityException {}
+  }
+
+  @BeforeAll
+  static void registerLogHandler() {
+    logHandler = new LogHandler();
+    LogManager.getLogManager().getLogger("").addHandler(logHandler);
+  }
+
+  @RepeatedTest(1000)
+  void testInParallel() {}
+
+  @AfterAll
+  static void assertNoWarnings() {
+    logHandler.assertNoWarnings();
+  }
+}


### PR DESCRIPTION
Before this change, `BazelJUnitOutputListener` wasn't thread-safe, resulting in exceptions such as the following:

```
java.util.ConcurrentModificationException
	at java.base/java.util.LinkedList$LLSpliterator.tryAdvance(LinkedList.java:1258)
	at java.base/java.util.stream.Streams$ConcatSpliterator.tryAdvance(Streams.java:720)
	at java.base/java.util.stream.ReferencePipeline.forEachWithCancel(ReferencePipeline.java:129)
	at java.base/java.util.stream.AbstractPipeline.copyIntoWithCancel(AbstractPipeline.java:527)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:513)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.FindOps$FindOp.evaluateSequential(FindOps.java:150)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.findFirst(ReferencePipeline.java:647)
	at com.github.bazel_contrib.contrib_rules_jvm.junit5.TestSuiteResult.get(TestSuiteResult.java:95)
	at com.github.bazel_contrib.contrib_rules_jvm.junit5.TestSuiteResult.lambda$get$3(TestSuiteResult.java:92)
        ...
```