### PR TITLE
Fix Security Manager warning with Java 17

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/Java17SystemExitToggle.java
@@ -28,7 +28,7 @@ public class Java17SystemExitToggle implements SystemExitToggle {
     if (Map.class.isAssignableFrom(callers.getClass())) {
       @SuppressWarnings("unchecked")
       Map<Class<?>, Boolean> map = Map.class.cast(callers);
-      map.put(getClass().getSuperclass(), true);
+      map.put(toggle.getClass(), true);
     }
   }
 


### PR DESCRIPTION
This is to fix:
```
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by com.github.bazel_contrib.contrib_rules_jvm.junit5.Java11SystemExitToggle (file:/path/to/junit5-runner.jar)
WARNING: Please consider reporting this to the maintainers of com.github.bazel_contrib.contrib_rules_jvm.junit5.Java11SystemExitToggle
WARNING: System::setSecurityManager will be removed in a future release
```

At some point, inheritance was replaced with delegation, but the registered class remained that of the earlier design, i.e. the superclass of `Java17SystemExitToggle`: formerly `Java11SystemExitToggle`, now `Object`.

The present change therefore simply consists in registering the delegated class instead, i.e. `Java11SystemExitToggle` as before.

Quick recap:
1. #89
2. #90
3. #92
4. #132
5. #134