### PR TITLE
Replace ctx.host_configuration with ctx.configuration

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -32,7 +32,7 @@ def _pmd_test_impl(ctx):
     if ctx.attr.target != None and not pmd_info.shallow:
         jars = ctx.attr.target[JavaInfo].transitive_runtime_jars.to_list()
         if len(jars) > 0:
-            aux_class_path = ctx.host_configuration.host_path_separator.join([jar.short_path for jar in jars])
+            aux_class_path = ctx.configuration.host_path_separator.join([jar.short_path for jar in jars])
             cmd.extend(["--aux-classpath", aux_class_path])
 
             # runfiles requires the depset to be in `default` order


### PR DESCRIPTION
This is to fix:

```
Traceback (most recent call last):
        File ".../external/contrib_rules_jvm/java/private/pmd.bzl", line 37, column 33, in _pmd_test_impl
                aux_class_path = ctx.host_configuration.host_path_separator.join([jar.short_path for jar in jars])
Error: 'ctx' value has no field or method 'host_configuration'
```
with bazel 7.0.0-pre.20230330.3

1. ctx.host_configuration got removed in bazel 7
2. host_path_separator's value doesn't depend on the configuration (the API is misleading by embedding it under ctx.configuration). So this is a no-op.

Inspired from grpc/grpc-java/pull/9742