### PR TITLE
pass tag for java_test_lib

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -90,6 +90,7 @@ def create_jvm_test_suite(
             srcs = nontest_srcs,
             testonly = True,
             visibility = visibility,
+            tags = tags,
             **library_attrs
         )
         if not _contains_label(deps or [], lib_dep_label):


### PR DESCRIPTION
when we add `no-tag` to ignore linter checks for all test code, it only applies to `test` target. We need to make the expanded `java_test_lib` target inherit this behavior as well.