### PR TITLE
Added java_maven_repository_name directive

### DIFF
--- a/java/gazelle/configure.go
+++ b/java/gazelle/configure.go
@@ -57,6 +57,7 @@ func (jc *Configurer) KnownDirectives() []string {
 		javaconfig.JavaTestFileSuffixes,
 		javaconfig.JavaTestMode,
 		javaconfig.JavaGenerateProto,
+		javaconfig.JavaMavenRepositoryName,
 	}
 }
 
@@ -108,6 +109,9 @@ func (jc *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 
 			case javaconfig.JavaTestMode:
 				cfg.SetTestMode(d.Value)
+
+			case javaconfig.JavaMavenRepositoryName:
+				cfg.SetMavenRepositoryName(d.Value)
 
 			case javaconfig.JavaGenerateProto:
 				switch d.Value {

--- a/java/gazelle/generate_test.go
+++ b/java/gazelle/generate_test.go
@@ -135,7 +135,7 @@ func TestSingleJavaTestFile(t *testing.T) {
 			var res language.GenerateResult
 
 			l := newTestJavaLang(t)
-			l.generateJavaTest(nil, "", f, tc.includePackageInName, stringsToPackageNames(tc.importedPackages), nil, &res)
+			l.generateJavaTest(nil, "", "maven", f, tc.includePackageInName, stringsToPackageNames(tc.importedPackages), nil, &res)
 
 			require.Len(t, res.Gen, 1, "want 1 generated rule")
 
@@ -227,7 +227,7 @@ func TestSuite(t *testing.T) {
 			var res language.GenerateResult
 
 			l := newTestJavaLang(t)
-			l.generateJavaTestSuite(nil, "blah", []string{src}, stringsToPackageNames([]string{pkg}), stringsToPackageNames(tc.importedPackages), nil, false, &res)
+			l.generateJavaTestSuite(nil, "blah", []string{src}, stringsToPackageNames([]string{pkg}), "maven", stringsToPackageNames(tc.importedPackages), nil, false, &res)
 
 			require.Len(t, res.Gen, 1, "want 1 generated rule")
 

--- a/java/gazelle/javaconfig/config.go
+++ b/java/gazelle/javaconfig/config.go
@@ -42,6 +42,10 @@ const (
 	// rules when a `proto_library` rule is present.
 	// Can be either "true" or "false". Defaults to "true".
 	JavaGenerateProto = "java_generate_proto"
+
+	// JavaMavenRepositoryName tells the code generator what the repository name that contains all maven dependencies is.
+	// Defaults to "maven"
+	JavaMavenRepositoryName = "java_maven_repository_name"
 )
 
 // Configs is an extension of map[string]*Config. It provides finding methods
@@ -67,6 +71,7 @@ func (c *Config) NewChild() *Config {
 		customTestFileSuffixes: c.customTestFileSuffixes,
 		annotationToAttribute:  c.annotationToAttribute,
 		excludedArtifacts:      clonedExcludedArtifacts,
+		mavenRepositoryName:    c.mavenRepositoryName,
 	}
 }
 
@@ -94,6 +99,7 @@ type Config struct {
 	customTestFileSuffixes *[]string
 	excludedArtifacts      map[string]struct{}
 	annotationToAttribute  map[string]map[string]bzl.Expr
+	mavenRepositoryName    string
 }
 
 type LoadInfo struct {
@@ -114,6 +120,7 @@ func New(repoRoot string) *Config {
 		customTestFileSuffixes: nil,
 		excludedArtifacts:      make(map[string]struct{}),
 		annotationToAttribute:  make(map[string]map[string]bzl.Expr),
+		mavenRepositoryName:    "maven",
 	}
 }
 
@@ -137,6 +144,14 @@ func (c *Config) GenerateProto() bool {
 
 func (c *Config) SetGenerateProto(generate bool) {
 	c.generateProto = generate
+}
+
+func (c *Config) MavenRepositoryName() string {
+	return c.mavenRepositoryName
+}
+
+func (c *Config) SetMavenRepositoryName(name string) {
+	c.mavenRepositoryName = name
 }
 
 func (c Config) MavenInstallFile() string {

--- a/java/gazelle/private/maven/resolver_test.go
+++ b/java/gazelle/private/maven/resolver_test.go
@@ -25,11 +25,11 @@ func TestResolver(t *testing.T) {
 
 	assertResolves(t, r, m, "com.google.common.collect", "@maven//:com_google_guava_guava")
 	assertResolves(t, r, m, "javax.annotation", "@maven//:com_google_code_findbugs_jsr305")
-	got, err := r.Resolve(types.NewPackageName("unknown.package"), m)
+	got, err := r.Resolve(types.NewPackageName("unknown.package"), m, "maven")
 	if err == nil {
 		t.Errorf("Want error finding label for unknown.package, got %v", got)
 	}
-	got, err = r.Resolve(types.NewPackageName("com.google.j2objc.annotations"), m)
+	got, err = r.Resolve(types.NewPackageName("com.google.j2objc.annotations"), m, "maven")
 	if err == nil {
 		t.Errorf("Want error finding label for excluded artifact, got %v", got)
 	}
@@ -37,7 +37,7 @@ func TestResolver(t *testing.T) {
 }
 
 func assertResolves(t *testing.T, r Resolver, excludePackages map[string]struct{}, pkg, wantLabelStr string) {
-	got, err := r.Resolve(types.NewPackageName(pkg), excludePackages)
+	got, err := r.Resolve(types.NewPackageName(pkg), excludePackages, "maven")
 	if err != nil {
 		t.Errorf("Error finding label for %v: %v", pkg, err)
 	}

--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -197,7 +197,7 @@ func (jr *Resolver) resolveSinglePackage(c *config.Config, pc *javaconfig.Config
 		return label.NoLabel, nil
 	}
 
-	if l, err := jr.lang.mavenResolver.Resolve(imp, pc.ExcludedArtifacts()); err == nil {
+	if l, err := jr.lang.mavenResolver.Resolve(imp, pc.ExcludedArtifacts(), pc.MavenRepositoryName()); err == nil {
 		return l, nil
 	}
 

--- a/java/gazelle/resolve_test.go
+++ b/java/gazelle/resolve_test.go
@@ -240,7 +240,7 @@ func testConfig(t *testing.T, args ...string) (*config.Config, []language.Langua
 
 type testResolver struct{}
 
-func (*testResolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]struct{}) (label.Label, error) {
+func (*testResolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]struct{}, mavenRepositoryName string) (label.Label, error) {
 	return label.NoLabel, errors.New("not implemented")
 }
 
@@ -280,7 +280,7 @@ func NewTestMavenResolver() *TestMavenResolver {
 	}
 }
 
-func (r *TestMavenResolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]struct{}) (label.Label, error) {
+func (r *TestMavenResolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]struct{}, mavenRepositoryName string) (label.Label, error) {
 	l, found := r.data[pkg]
 	if !found {
 		return label.NoLabel, fmt.Errorf("unexpected import: %s", pkg)

--- a/java/gazelle/testdata/maven/BUILD.in
+++ b/java/gazelle/testdata/maven/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:java_maven_repository_name vendor_java

--- a/java/gazelle/testdata/maven/BUILD.out
+++ b/java/gazelle/testdata/maven/BUILD.out
@@ -1,0 +1,1 @@
+# gazelle:java_maven_repository_name vendor_java

--- a/java/gazelle/testdata/maven/src/main/java/com/example/compare/BUILD.out
+++ b/java/gazelle/testdata/maven/src/main/java/com/example/compare/BUILD.out
@@ -4,7 +4,7 @@ java_library(
     name = "compare",
     srcs = ["Compare.java"],
     visibility = ["//:__subpackages__"],
-    deps = ["@maven//:com_google_guava_guava"],
+    deps = ["@vendor_java//:com_google_guava_guava"],
 )
 
 java_binary(

--- a/java/gazelle/testdata/maven/src/main/java/com/example/myproject/BUILD.out
+++ b/java/gazelle/testdata/maven/src/main/java/com/example/myproject/BUILD.out
@@ -4,7 +4,7 @@ java_library(
     name = "myproject",
     srcs = ["App.java"],
     visibility = ["//:__subpackages__"],
-    deps = ["@maven//:com_google_guava_guava"],
+    deps = ["@vendor_java//:com_google_guava_guava"],
 )
 
 java_binary(

--- a/java/gazelle/testdata/maven/src/test/java/com/example/myproject/BUILD.out
+++ b/java/gazelle/testdata/maven/src/test/java/com/example/myproject/BUILD.out
@@ -5,6 +5,6 @@ java_test_suite(
     srcs = ["AppTest.java"],
     deps = [
         "//src/main/java/com/example/myproject",
-        "@maven//:junit_junit",
+        "@vendor_java//:junit_junit",
     ],
 )


### PR DESCRIPTION
Some repositories can run maven_install with a different name or maintain multiple sets of maven dependencies, this change will allow overriding `@maven` with whatever custom name that is needed.
