### PR TITLE
junit5: pass static nested classes to the launcher

### DIFF
--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -16,12 +16,16 @@ SHARDING_TEST = [
     "ShardingTest.java",
 ]
 
+VINTAGE_NESTED_TEST = [
+    "NestedClassesVintageTest.java",
+]
+
 java_test_suite(
     name = "small-tests",
     size = "small",
     srcs = glob(
         ["*.java"],
-        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST,
+        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST + VINTAGE_NESTED_TEST,
     ),
     exclude_engines = ["junit-vintage"],
     include_engines = ["junit-jupiter"],
@@ -33,6 +37,20 @@ java_test_suite(
         artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
         artifact("org.mockito:mockito-core", "contrib_rules_jvm_tests"),
         artifact("org.opentest4j:opentest4j", "contrib_rules_jvm_tests"),
+    ] + junit5_vintage_deps("contrib_rules_jvm_tests"),
+)
+
+java_test_suite(
+    name = "vintage-nested-test",
+    size = "small",
+    srcs = [
+        "NestedClassesVintageTest.java",
+    ],
+    exclude_engines = ["junit-jupiter"],
+    include_engines = ["junit-vintage"],
+    runner = "junit5",
+    deps = [
+        "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
     ] + junit5_vintage_deps("contrib_rules_jvm_tests"),
 )
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/NestedClassesTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/NestedClassesTest.java
@@ -1,0 +1,28 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class NestedClassesTest {
+  static class First {
+    @Test
+    public void shouldBeExecuted() {
+      System.out.println(">>>> Executed test in NestedClassesTest$First");
+    }
+  }
+
+  @Nested
+  @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
+  class Second {
+    @Test
+    public void shouldBeExecuted() {
+      System.out.println(">>>> Executed test in NestedClassesTest$Second");
+    }
+  }
+
+  @Test
+  public void shouldBeExecuted() {
+    System.out.println(">>>> Executed test in NestedClassesTest");
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/NestedClassesVintageTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/NestedClassesVintageTest.java
@@ -1,0 +1,15 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+@RunWith(Enclosed.class)
+public class NestedClassesVintageTest {
+  public static class First {
+    @Test
+    public void shouldBeExecuted() {
+      System.out.println(">>>> Executed test in NestedClassesVintageTest$First");
+    }
+  }
+}


### PR DESCRIPTION
This change iterates over all the static nested classes of the test class and adds them to LauncherDiscoveryRequestBuilder to allow running tests within static nested classes.

While Java allows more than one level of nesting, we limit our search to one level of nesting at the moment.

Junit4 tests annotated with `RunWith(Enclosed.class)` need to be special cased.

Refer: https://github.com/gradle/gradle/issues/4427