### PR TITLE
Handle java_library being remapped with map_kind

### DIFF
--- a/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/expectedStderr.txt
+++ b/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/expectedStderr.txt
@@ -1,0 +1,1 @@
+[90m12:00AM[0m [31mWRN[0m [1mjava/gazelle/private/maven/resolver.go:XXX[0m[36m >[0m not loading maven dependencies [36merror=[0m[31m"open %WORKSPACEPATH%/maven_install.json: no such file or directory"[0m [36m_c=[0mmaven-resolver-data

--- a/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/expectedStderr.txt
+++ b/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/expectedStderr.txt
@@ -1,1 +1,1 @@
-[90m12:00AM[0m [31mWRN[0m [1mjava/gazelle/private/maven/resolver.go:XXX[0m[36m >[0m not loading maven dependencies [36merror=[0m[31m"open %WORKSPACEPATH%/maven_install.json: no such file or directory"[0m [36m_c=[0mmaven-resolver-data
+[90m12:00AM[0m [31mWRN[0m [1mjava/gazelle/private/maven/resolver.go:XXX[0m[36m >[0m not loading maven dependencies [36merror=[0m[31m"open %WORKSPACEPATH%/maven_install.json: no such file or directory"[0m [36m_c=[0mmaven-resolver

--- a/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/BUILD.in
+++ b/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/BUILD.in
@@ -1,0 +1,10 @@
+load("//libs/bazel/java:rules_java.bzl", "generic_java_library")
+
+# gazelle:map_kind java_library generic_java_library //libs/bazel/java:rules_java.bzl
+
+generic_java_library(
+    name = "hello",
+    srcs = ["Hello.java"],
+    visibility = ["//:__subpackages__"],
+    runtime_deps = ["//foo/bar"],
+)

--- a/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/BUILD.out
+++ b/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/BUILD.out
@@ -1,0 +1,10 @@
+load("//libs/bazel/java:rules_java.bzl", "generic_java_library")
+
+# gazelle:map_kind java_library generic_java_library //libs/bazel/java:rules_java.bzl
+
+generic_java_library(
+    name = "hello",
+    srcs = ["Hello.java"],
+    visibility = ["//:__subpackages__"],
+    runtime_deps = ["//foo/bar"],
+)

--- a/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/Hello.java
+++ b/java/gazelle/testdata/lib_with_runtime_deps_and_map_kind/src/main/java/com/example/hello/Hello.java
@@ -1,0 +1,7 @@
+package com.example.hello;
+
+public class Hello {
+    public static void sayHi() {
+        System.out.println("Hi!");
+    }
+}


### PR DESCRIPTION
When preserving runtime dependencies of existing rules use the new rule name if it was remapped.