### PR TITLE
Fix Gazelle collision error format

### DIFF
--- a/java/gazelle/private/maven/resolver.go
+++ b/java/gazelle/private/maven/resolver.go
@@ -80,7 +80,7 @@ func (r *resolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]s
 	default:
 		r.logger.Error().Msg("Append one of the following to BUILD.bazel:")
 		for _, k := range filtered {
-			r.logger.Error().Msgf("# gazelle:resolve java %s %s", pkg, k)
+			r.logger.Error().Msgf("# gazelle:resolve java %s %s", pkg.Name, k)
 		}
 
 		return label.NoLabel, errors.New("many possible imports")


### PR DESCRIPTION
Updates the error message to ease copy-paste into the build file.

Before:

    Append one of the following to BUILD.bazel
    # gazelle:resolve java {com.example.a.b.c} @maven//:com_example_a_b_c
    # gazelle:resolve java {com.foo.a.b.c} @maven//:com_foo_a_b_c

After:

    Append one of the following to BUILD.bazel
    # gazelle:resolve java com.example.a.b.c @maven//:com_example_a_b_c
    # gazelle:resolve java com.foo.a.b.c @maven//:com_foo_a_b_c