### PR TITLE
Avoid initialising classes when looking for tests

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -53,7 +53,7 @@ public class ActualRunner implements RunsTest {
 
       final Class<?> testClass;
       try {
-        testClass = Class.forName(testClassName);
+        testClass = Class.forName(testClassName, false, getClass().getClassLoader());
       } catch (ClassNotFoundException e) {
         throw new RuntimeException("Failed to find testClass", e);
       }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/StaticInitializerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/StaticInitializerTest.java
@@ -1,0 +1,20 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class StaticInitializerTest extends StaticInitializerTestBase {
+
+  // The `value` will only be set if the parent class's `BeforeAll` method
+  // has been called. If we've called `Class.forName(String)` in the
+  // `ActualRunner` then this value will be `null`, so the test won't even
+  // start. This test verifies that while we can still find tests, we're
+  // not initialising classes until they're used.
+  private static final int length = value.length();
+
+  @Test
+  public void doSomethingToForceInitializersToBeRun() {
+    assertNotEquals(0, length);
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/StaticInitializerTestBase.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/StaticInitializerTestBase.java
@@ -1,0 +1,13 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import org.junit.jupiter.api.BeforeAll;
+
+public class StaticInitializerTestBase {
+
+  protected static String value;
+
+  @BeforeAll
+  public static void setTestData() {
+    value = "Hello, World!";
+  }
+}


### PR DESCRIPTION
This can cause hidden problems where there are ordering issues between (eg) setup methods and static fields in classes.