### PR TITLE
junit5: Add support for `--test_runner_fail_fast`

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+import org.junit.jupiter.engine.Constants;
 import org.junit.platform.engine.DiscoverySelector;
 import org.junit.platform.engine.discovery.DiscoverySelectors;
 import org.junit.platform.launcher.Launcher;
@@ -44,10 +45,11 @@ public class ActualRunner implements RunsTest {
 
     try (BazelJUnitOutputListener bazelJUnitXml = new BazelJUnitOutputListener(xmlOut)) {
       CommandLineSummary summary = new CommandLineSummary();
+      FailFastExtension failFastExtension = new FailFastExtension();
 
       LauncherConfig config =
           LauncherConfig.builder()
-              .addTestExecutionListeners(bazelJUnitXml, summary)
+              .addTestExecutionListeners(bazelJUnitXml, summary, failFastExtension)
               .addPostDiscoveryFilters(TestSharding.makeShardFilter())
               .build();
 
@@ -74,7 +76,9 @@ public class ActualRunner implements RunsTest {
           LauncherDiscoveryRequestBuilder.request()
               .selectors(classSelectors)
               .configurationParameter(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, "true")
-              .configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true");
+              .configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true")
+              .configurationParameter(
+                  Constants.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME, "true");
 
       String filter = System.getenv("TESTBRIDGE_TEST_ONLY");
       request.filters(new PatternFilter(filter));

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -58,11 +58,18 @@ java_library(
         "--release",
         "8",
     ],
+    resource_strip_prefix = package_name(),
+    resources = ["META-INF/services/org.junit.jupiter.api.extension.Extension"],
     deps = [
         ":system-exit-toggle",
         # The only dependencies here are those required to run
         # a junit5 test. We try not to pollute the classpath, so
         # be very careful when adding new deps here.
+        #
+        # junit-jupiter-api is only a compilation dependency and not listed in JUNIT5_DEPS. This is
+        # fine as it is a transitive dependency of junit-jupiter-engine and will thus be available
+        # at runtime.
+        artifact("org.junit.jupiter:junit-jupiter-api"),
         artifact("org.junit.jupiter:junit-jupiter-engine"),
         artifact("org.junit.platform:junit-platform-commons"),
         artifact("org.junit.platform:junit-platform-engine"),

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/FailFastExtension.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/FailFastExtension.java
@@ -1,0 +1,44 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.engine.TestExecutionResult;
+import org.junit.platform.engine.TestExecutionResult.Status;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+
+public class FailFastExtension implements ExecutionCondition, TestExecutionListener {
+  /**
+   * This environment variable is set to 1 if Bazel is run with --test_runner_fail_fast, indicating
+   * that the test runner should exit as soon as possible after the first failure. {@see
+   * https://github.com/bazelbuild/bazel/commit/957554037ced26dc1860b9c23445a8ccc44f697e}
+   */
+  private static final boolean SHOULD_FAIL_FAST =
+      "1".equals(System.getenv("TESTBRIDGE_TEST_RUNNER_FAIL_FAST"));
+
+  private static final AtomicBoolean SOME_TEST_FAILED = new AtomicBoolean();
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext extensionContext) {
+    if (!SHOULD_FAIL_FAST) {
+      return ConditionEvaluationResult.enabled(
+          "Running test since --test_runner_fail_fast is not enabled");
+    }
+    if (SOME_TEST_FAILED.get()) {
+      return ConditionEvaluationResult.disabled(
+          "Skipping test since --test_runner_fail_fast is enabled and another test has failed");
+    } else {
+      return ConditionEvaluationResult.enabled("Running test since no other test has failed yet");
+    }
+  }
+
+  @Override
+  public void executionFinished(
+      TestIdentifier testIdentifier, TestExecutionResult testExecutionResult) {
+    if (SHOULD_FAIL_FAST && testExecutionResult.getStatus().equals(Status.FAILED)) {
+      SOME_TEST_FAILED.set(true);
+    }
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -92,6 +92,9 @@ public class JUnit5Runner {
 
   private static void detectJUnit5Classes() {
     checkClass(
+        "org.junit.jupiter.api.extension.ExecutionCondition",
+        "org.junit.jupiter:junit-jupiter-api");
+    checkClass(
         "org.junit.jupiter.engine.JupiterTestEngine", "org.junit.jupiter:junit-jupiter-engine");
     checkClass(
         "org.junit.platform.commons.JUnitException", "org.junit.platform:junit-platform-commons");

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+com.github.bazel_contrib.contrib_rules_jvm.junit5.FailFastExtension


### PR DESCRIPTION
When the Bazel flag `--test_runner_fail_fast` is enabled, the JUnit 5 runner will now skip all other tests after the first one has failed in an attempt to speed up the (failing) test run. This is useful in some CI setups as well as during bisection.