### PR TITLE
Enable runfiles on Windows

### DIFF
--- a/examples/gazelle/.bazelrc
+++ b/examples/gazelle/.bazelrc
@@ -1,0 +1,5 @@
+common --enable_platform_specific_config
+
+# https://bazel.build/docs/windows#symlink
+startup --windows_enable_symlinks
+run:windows --enable_runfiles


### PR DESCRIPTION
This is required by the Java gazelle implementation.