### PR TITLE
Fix up BCR presubmit

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,7 @@
 bcr_test_module:
+  module_path: ""
   matrix:
-    platform: ["debian10", "macos", "ubuntu2004", "windows"]
+    platform: ["debian10", "macos", "ubuntu2004"]
   tasks:
     gazelle:
       working_directory: "examples/gazelle"


### PR DESCRIPTION
* Set module_path
* Stop testing on Windows - it turns out contrib_rules_jvm currently doesn't work on Windows in a number of ways.