### PR TITLE
Rename format pipeline

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  format:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Our CI checks aren't currently required to merge.

As far as I can tell, this name key is the only thing you can use to describe whether a check is required, and the fact that it matches the name for the other GitHub action means we can't make both required.