### PR TITLE
`rules_jvm_external` version 6 depends on `rules_java`

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -11,6 +11,7 @@ def contrib_rules_jvm_deps():
         strip_prefix = "apple_rules_lint-0.3.2",
         url = "https://github.com/apple/apple_rules_lint/archive/refs/tags/0.3.2.tar.gz",
     )
+
     maybe(
         http_archive,
         name = "io_bazel_stardoc",
@@ -39,6 +40,39 @@ def contrib_rules_jvm_deps():
         strip_prefix = "protobuf-{}".format(PROTOBUF_VERSION),
         urls = ["https://github.com/protocolbuffers/protobuf/archive/v{}.tar.gz".format(PROTOBUF_VERSION)],
     )
+
+    # The `rules_java` major version is tied to the major version of Bazel that it supports,
+    # so this is different from the version in the MODULE file.
+    major_version = native.bazel_version.partition(".")[0]
+    if major_version == "5":
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/5.5.1/rules_java-5.5.1.tar.gz",
+            ],
+            sha256 = "73b88f34dc251bce7bc6c472eb386a6c2b312ed5b473c81fe46855c248f792e0",
+        )
+
+    elif major_version == "6":
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/6.5.2/rules_java-6.5.2.tar.gz",
+            ],
+            sha256 = "16bc94b1a3c64f2c36ceecddc9e09a643e80937076b97e934b96a8f715ed1eaa",
+        )
+
+    else:
+        maybe(
+            http_archive,
+            name = "rules_java",
+            urls = [
+                "https://github.com/bazelbuild/rules_java/releases/download/7.3.2/rules_java-7.3.2.tar.gz",
+            ],
+            sha256 = "3121a00588b1581bd7c1f9b550599629e5adcc11ba9c65f482bbd5cfe47fdf30",
+        )
 
     maybe(
         zip_repository,

--- a/setup.bzl
+++ b/setup.bzl
@@ -1,8 +1,17 @@
 load("@apple_rules_lint//lint:setup.bzl", "ruleset_lint_setup")
 load("@contrib_rules_jvm_deps//:compat.bzl", "compat_repositories")
 load("@contrib_rules_jvm_deps//:defs.bzl", "pinned_maven_install")
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 
 def contrib_rules_jvm_setup():
     ruleset_lint_setup()
+
+    # When using bazel 5, we have undefined toolchains from rules_js. This should be fine to skip, since we only need
+    # it for the `JavaInfo` definition.
+    major_version = native.bazel_version.partition(".")[0]
+    if major_version != "5":
+        rules_java_dependencies()
+        rules_java_toolchains()
+
     pinned_maven_install()
     compat_repositories()


### PR DESCRIPTION
This lays the groundwork for pulling in the same version as `rules_jvm_external` when using a workspace-based build.