### PR TITLE
gazelle: Fix java_binary targets in test trees

### DIFF
--- a/java/gazelle/testdata/bin_in_test_tree/BUILD.in
+++ b/java/gazelle/testdata/bin_in_test_tree/BUILD.in
@@ -1,0 +1,1 @@
+# gazelle:resolve java org.junit @maven//:junit_junit

--- a/java/gazelle/testdata/bin_in_test_tree/BUILD.out
+++ b/java/gazelle/testdata/bin_in_test_tree/BUILD.out
@@ -1,0 +1,1 @@
+# gazelle:resolve java org.junit @maven//:junit_junit

--- a/java/gazelle/testdata/bin_in_test_tree/expectedStderr.txt
+++ b/java/gazelle/testdata/bin_in_test_tree/expectedStderr.txt
@@ -1,0 +1,1 @@
+{"level":"warn","_c":"maven-resolver","error":"open %WORKSPACEPATH%/maven_install.json: no such file or directory","message":"not loading maven dependencies"}

--- a/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/BUILD.out
+++ b/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/BUILD.out
@@ -1,0 +1,19 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@contrib_rules_jvm//java:defs.bzl", "java_test_suite")
+
+java_binary(
+    name = "SomeTestBinary",
+    testonly = True,
+    main_class = "com.example.test.SomeTestBinary",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":test-test-lib"],
+)
+
+java_test_suite(
+    name = "test",
+    srcs = [
+        "SomeOtherTest.java",
+        "SomeTestBinary.java",
+    ],
+    deps = ["@maven//:junit_junit"],
+)

--- a/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/SomeOtherTest.java
+++ b/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/SomeOtherTest.java
@@ -1,0 +1,8 @@
+package com.example.test;
+
+import org.junit.Test;
+
+public class SomeOtherTest {
+  @Test
+  public void testPasses() {}
+}

--- a/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/SomeTestBinary.java
+++ b/java/gazelle/testdata/bin_in_test_tree/src/test/java/com/example/test/SomeTestBinary.java
@@ -1,0 +1,7 @@
+package com.example.test;
+
+public class SomeTestBinary {
+  public static void main(String[] args) {
+    System.out.println("Test passed!");
+  }
+}


### PR DESCRIPTION
Before they were generated with a dependency on a target which didn't exist.

Instead, add the dependency on the -test-lib target of the java_test_suite in their package, and mark them as testonly.

This is hopefully a pretty rare edge-case, but has been observed.