### PR TITLE
update rules_jvm_external to 6.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -51,7 +51,7 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_jvm_external",
-    version = "5.3",
+    version = "6.0",
 )
 bazel_dep(
     name = "rules_proto",


### PR DESCRIPTION
We use `java_export` in our project and need to use some new feature that was added in to newly released `rules_jvm_external`