### PR TITLE
Fix "failed to call RLocation: runfile (...)/Main: file does not exist" 

### DIFF
--- a/java/gazelle/private/servermanager/servermanager.go
+++ b/java/gazelle/private/servermanager/servermanager.go
@@ -92,11 +92,15 @@ func locateJavaparser() (string, error) {
 	}
 
 	// We want //java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators:Main
-	loc, err := rf.Rlocation("contrib_rules_jvm/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/Main")
+	javaparserPath := "contrib_rules_jvm/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/Main"
+	loc, err := rf.Rlocation(javaparserPath)
+	if err != nil {
+	  loc, err = rf.Rlocation(javaparserPath + ".exe")
+	}
+
 	if err != nil {
 		return "", fmt.Errorf("failed to call RLocation: %w", err)
 	}
-
 	return loc, nil
 }
 

--- a/java/gazelle/private/servermanager/servermanager.go
+++ b/java/gazelle/private/servermanager/servermanager.go
@@ -95,7 +95,7 @@ func locateJavaparser() (string, error) {
 	javaparserPath := "contrib_rules_jvm/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/Main"
 	loc, err := rf.Rlocation(javaparserPath)
 	if err != nil {
-	  loc, err = rf.Rlocation(javaparserPath + ".exe")
+		loc, err = rf.Rlocation(javaparserPath + ".exe")
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fix "bazel run gazelle" failing on Windows with the following error:
> 1:57PM FTL external/contrib_rules_jvm/java/gazelle/configure.go:139 > could not start javaparser error="failed to start / connect to javaparser server: failed to find javaparser in runfiles: failed to call RLocation: runfile contrib_rules_jvm/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/Main: file does not exist" (#257)