### PR TITLE
Fix "panic: runtime error: invalid memory address or nil pointer dereference"

### DIFF
--- a/java/gazelle/configure.go
+++ b/java/gazelle/configure.go
@@ -3,8 +3,8 @@ package gazelle
 import (
 	"flag"
 	"fmt"
-	"strings"
 	"path/filepath"
+	"strings"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/javaparser"

--- a/java/gazelle/configure.go
+++ b/java/gazelle/configure.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"path/filepath"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/javaparser"
@@ -78,11 +79,11 @@ func (jc *Configurer) initRootConfig(c *config.Config) javaconfig.Configs {
 
 func (jc *Configurer) Configure(c *config.Config, rel string, f *rule.File) {
 	cfgs := jc.initRootConfig(c)
-	cfg, exists := cfgs[rel]
+	cfg, exists := cfgs[filepath.FromSlash(rel)]
 	if !exists {
 		parent := cfgs.ParentForPackage(rel)
 		cfg = parent.NewChild()
-		cfgs[rel] = cfg
+		cfgs[filepath.FromSlash(rel)] = cfg
 	}
 
 	if f != nil {

--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -48,7 +48,7 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	log := l.logger.With().Str("step", "GenerateRules").Str("rel", args.Rel).Logger()
 
 	cfgs := args.Config.Exts[languageName].(javaconfig.Configs)
-	cfg := cfgs[args.Rel]
+	cfg := cfgs[filepath.FromSlash(args.Rel)]
 
 	var res language.GenerateResult
 	if !cfg.ExtensionEnabled() {

--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"path/filepath"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/java"
@@ -84,7 +85,7 @@ func (Resolver) Embeds(r *rule.Rule, from label.Label) []label.Label {
 func (jr Resolver) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, r *rule.Rule, imports interface{}, from label.Label) {
 	resolveInput := imports.(types.ResolveInput)
 
-	packageConfig := c.Exts[languageName].(javaconfig.Configs)[from.Pkg]
+	packageConfig := c.Exts[languageName].(javaconfig.Configs)[filepath.FromSlash(from.Pkg)]
 	if packageConfig == nil {
 		jr.lang.logger.Fatal().Msg("failed retrieving package config")
 	}

--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -3,8 +3,8 @@ package gazelle
 import (
 	"errors"
 	"fmt"
-	"sort"
 	"path/filepath"
+	"sort"
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/javaconfig"
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/java"


### PR DESCRIPTION
Fix `bazel run gazelle` failing on Windows with
> panic: runtime error: invalid memory address or nil pointer dereference

because of the incorrect path separator when accessing the Configs map (#260).