### PR TITLE
Fix "java.nio.file.InvalidPathException: Illegal char <:> at index 2"

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -180,7 +180,7 @@ public class ClasspathParser {
     @Override
     public Void visitCompilationUnit(CompilationUnitTree t, Void v) {
       compileUnit = t;
-      fileName = Paths.get(compileUnit.getSourceFile().toUri().getPath()).getFileName().toString();
+      fileName = Paths.get(compileUnit.getSourceFile().toUri()).getFileName().toString();
       currentClassName = null;
       currentFileImports = new HashMap<>();
 


### PR DESCRIPTION
Fix `bazel run gazelle` failing with `java.nio.file.InvalidPathException: Illegal char <:> at index 2` (#262).