### PR TITLE
Use path not filepath for package parents

### DIFF
--- a/java/gazelle/javaconfig/config.go
+++ b/java/gazelle/javaconfig/config.go
@@ -2,6 +2,7 @@ package javaconfig
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -78,7 +79,7 @@ func (c *Config) NewChild() *Config {
 
 // ParentForPackage returns the parent Config for the given Bazel package.
 func (c *Configs) ParentForPackage(pkg string) *Config {
-	dir := filepath.Dir(pkg)
+	dir := path.Dir(pkg)
 	if dir == "." {
 		dir = ""
 	}


### PR DESCRIPTION
We're using this to find the parent of a package, not a filesystem path, and packages always use `/`.

Fixes #260
Closes #261