### PR TITLE
Only call rlocation once

### DIFF
--- a/java/gazelle/private/servermanager/servermanager.go
+++ b/java/gazelle/private/servermanager/servermanager.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -93,11 +94,10 @@ func locateJavaparser() (string, error) {
 
 	// We want //java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators:Main
 	javaparserPath := "contrib_rules_jvm/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/Main"
-	loc, err := rf.Rlocation(javaparserPath)
-	if err != nil {
-		loc, err = rf.Rlocation(javaparserPath + ".exe")
+	if runtime.GOOS == "windows" {
+		javaparserPath += ".exe"
 	}
-
+	loc, err := rf.Rlocation(javaparserPath)
 	if err != nil {
 		return "", fmt.Errorf("failed to call RLocation: %w", err)
 	}


### PR DESCRIPTION
This leads to slightly faster runtime, and slightly less confusing error messages if the file can't be found.