### PR TITLE
Rename IsTestPath to IsTestPackage

### DIFF
--- a/java/gazelle/private/java/java.go
+++ b/java/gazelle/private/java/java.go
@@ -6,21 +6,22 @@ import (
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/types"
 )
 
-// IsTestPath tries to detect if the directory would contain test files of not.
-func IsTestPath(dir string) bool {
-	if strings.HasPrefix(dir, "javatests/") {
+// IsTestPackage tries to detect if the directory would contain test files of not.
+// It assumes dir is a forward-slashed package name, not a possibly-back-slashed filepath.
+func IsTestPackage(pkg string) bool {
+	if strings.HasPrefix(pkg, "javatests/") {
 		return true
 	}
 
-	if strings.Contains(dir, "src/") {
-		afterSrc := strings.SplitAfterN(dir, "src/", 2)[1]
+	if strings.Contains(pkg, "src/") {
+		afterSrc := strings.SplitAfterN(pkg, "src/", 2)[1]
 		firstDir := strings.Split(afterSrc, "/")[0]
 		if strings.HasSuffix(strings.ToLower(firstDir), "test") {
 			return true
 		}
 	}
 
-	return strings.Contains(dir, "/test/")
+	return strings.Contains(pkg, "/test/")
 }
 
 // This list was derived from a script along the lines of:

--- a/java/gazelle/private/java/java_test.go
+++ b/java/gazelle/private/java/java_test.go
@@ -1,31 +1,28 @@
 package java
 
 import (
-	"path/filepath"
 	"testing"
 )
 
-func TestIsTestPath(t *testing.T) {
+func TestIsTestPackage(t *testing.T) {
 	tests := map[string]bool{
-		"": false,
-		"java/client/src/org/openqa/selenium/WebDriver.java":                  false,
-		"java/client/test/org/openqa/selenium/WebElementTest.java":            true,
-		"java/com/example/platform/githubhook/GithubHookModule.java":          false,
-		"javatests/com/example/platform/githubhook/GithubHookModuleTest.java": true,
-		"project1/src/main/java/com/example/myproject/App.java":               false,
-		"project1/src/test/java/com/example/myproject/TestApp.java":           true,
-		"project1/src/integrationTest/more/Things.java":                       true,
-		"src/main/java/com/example/myproject/App.java":                        false,
-		"src/test/java/com/example/myproject/TestApp.java":                    true,
-		"src/main/com/example/perftest/Query.java":                            false,
-		"src/main/com/example/perftest/TestBase.java":                         false,
-		"test-utils/src/main/com/example/project/App.java":                    false,
+		"":                                             false,
+		"java/client/src/org/openqa/selenium":          false,
+		"java/client/test/org/openqa/selenium":         true,
+		"java/com/example/platform/githubhook":         false,
+		"javatests/com/example/platform/githubhook":    true,
+		"project1/src/main/java/com/example/myproject": false,
+		"project1/src/test/java/com/example/myproject": true,
+		"project1/src/integrationTest/more":            true,
+		"src/main/java/com/example/myproject":          false,
+		"src/test/java/com/example/myproject":          true,
+		"src/main/com/example/perftest":                false,
+		"test-utils/src/main/com/example/project":      false,
 	}
 
-	for path, want := range tests {
-		t.Run(path, func(t *testing.T) {
-			dir := filepath.Dir(path)
-			if got := IsTestPath(dir); got != want {
+	for pkg, want := range tests {
+		t.Run(pkg, func(t *testing.T) {
+			if got := IsTestPackage(pkg); got != want {
 				t.Errorf("isTest() = %v, want %v", got, want)
 			}
 		})

--- a/java/gazelle/private/javaparser/javaparser.go
+++ b/java/gazelle/private/javaparser/javaparser.go
@@ -111,7 +111,7 @@ func (r Runner) ParsePackage(ctx context.Context, in *ParsePackageRequest) (*jav
 		ImportedPackagesWithoutSpecificClasses: importedPackages,
 		Mains:                                  mains,
 		Files:                                  sorted_set.NewSortedSet(in.Files),
-		TestPackage:                            java.IsTestPath(in.Rel),
+		TestPackage:                            java.IsTestPackage(in.Rel),
 		PerClassMetadata:                       perClassMetadata,
 	}, nil
 }


### PR DESCRIPTION
This is actually operating on package names, and we only ever give it package names.

This is sigificant because package names always have / as path separators, whereas on Windows, paths use \ as path separators.

This code should always be operating on /s. The code already assumed as much, so be more clear in the code and tests around it that this is what we're doing.