### PR TITLE
Shorten path to example file

### DIFF
--- a/examples/gazelle/src/test/com/example/gazelle/BUILD.bazel
+++ b/examples/gazelle/src/test/com/example/gazelle/BUILD.bazel
@@ -1,10 +1,11 @@
+load("@contrib_rules_jvm//java:defs.bzl", "java_test_suite")
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 
 genquery(
     name = "generated_targets",
-    expression = "kind(java_test, deps(//src/test/com/github/bazel_contrib/contrib_rules_jvm/examples/gazelle:gazelle))",
+    expression = "kind(java_test, deps(//src/test/com/example/gazelle:gazelle))",
     opts = ["--output=label_kind"],
-    scope = ["//src/test/com/github/bazel_contrib/contrib_rules_jvm/examples/gazelle"],
+    scope = ["//src/test/com/example/gazelle"],
 )
 
 diff_test(

--- a/examples/gazelle/src/test/com/example/gazelle/ExampleTest.java
+++ b/examples/gazelle/src/test/com/example/gazelle/ExampleTest.java
@@ -1,4 +1,4 @@
-package com.github.bazel_contrib.contrib_rules_jvm.examples.gazelle;
+package com.example.gazelle;
 
 import org.junit.jupiter.api.Test;
 

--- a/examples/gazelle/src/test/com/example/gazelle/expected-query-output
+++ b/examples/gazelle/src/test/com/example/gazelle/expected-query-output
@@ -1,0 +1,1 @@
+java_test rule //src/test/com/example/gazelle:ExampleTest

--- a/examples/gazelle/src/test/com/github/bazel_contrib/contrib_rules_jvm/examples/gazelle/expected-query-output
+++ b/examples/gazelle/src/test/com/github/bazel_contrib/contrib_rules_jvm/examples/gazelle/expected-query-output
@@ -1,1 +1,0 @@
-java_test rule //src/test/com/github/bazel_contrib/contrib_rules_jvm/examples/gazelle:ExampleTest


### PR DESCRIPTION
Otherwise the diff_test fails on Windows because the path is too long.