### PR TITLE
Mark `github.com/ghodss/yaml` as requiring external resolution

### DIFF
--- a/third_party/go/repositories.bzl
+++ b/third_party/go/repositories.bzl
@@ -192,6 +192,7 @@ def go_deps():
         importpath = "github.com/ghodss/yaml",
         sum = "h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=",
         version = "v1.0.0",
+        build_external = "external",
     )
     go_repository(
         name = "com_github_godbus_dbus_v5",


### PR DESCRIPTION
Without this, builds that use strict Go dependencies may fail because the generated build file is not complete.