### PR TITLE
Escape invalid XML chars in testCase and testSuite names

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
@@ -47,7 +47,7 @@ class TestCaseXmlRenderer {
     }
 
     xml.writeStartElement("testcase");
-    xml.writeAttribute("name", name);
+    xml.writeAttribute("name", escapeIllegalCharacters(name));
     xml.writeAttribute("classname", LegacyReportingUtils.getClassName(testPlan, id));
 
     /* @Nullable */ Duration maybeDuration = test.getDuration();

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
@@ -1,5 +1,6 @@
 package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 
+import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.escapeIllegalCharacters;
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeTextElement;
 
 import java.util.Collection;
@@ -19,7 +20,7 @@ class TestSuiteXmlRenderer {
       throws XMLStreamException {
     xml.writeStartElement("testsuite");
 
-    xml.writeAttribute("name", suite.getId().getLegacyReportingName());
+    xml.writeAttribute("name", escapeIllegalCharacters(suite.getId().getLegacyReportingName()));
     xml.writeAttribute("tests", String.valueOf(tests.size()));
 
     int errors = 0;

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOuputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOuputListenerTest.java
@@ -263,6 +263,38 @@ public class BazelJUnitOuputListenerTest {
     assertEquals("&#27;[31mAlso bad!&#27;[0m", text);
   }
 
+  @Test
+  public void ensureTestCaseNamesAreProperlyEscaped() {
+    var testDescriptor = new StubbedTestDescriptor(createId("Weird\bname"));
+    var identifier = TestIdentifier.from(testDescriptor);
+
+    var testCaseData = new TestData(identifier);
+    testCaseData.mark(TestExecutionResult.successful());
+
+    Document xml = generateTestXml(Mockito.mock(TestPlan.class), testCaseData);
+
+    Node item = xml.getElementsByTagName("testcase").item(0);
+    String testName = item.getAttributes().getNamedItem("name").getNodeValue();
+
+    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name", testName);
+  }
+
+  @Test
+  public void ensureTestSuiteNamesAreProperlyEscaped() {
+    var testDescriptor = new StubbedTestDescriptor(createId("Weird\bname"));
+    var identifier = TestIdentifier.from(testDescriptor);
+
+    var testSuiteData = new TestData(identifier);
+    testSuiteData.mark(TestExecutionResult.successful());
+
+    Document xml = generateTestXml(Mockito.mock(TestPlan.class), testSuiteData, List.of());
+
+    Node item = xml.getElementsByTagName("testsuite").item(0);
+    String testName = item.getAttributes().getNamedItem("name").getNodeValue();
+
+    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name()]", testName);
+  }
+
   private Document generateTestXml(TestPlan testPlan, TestData testCase) {
     return generateDocument(xml -> new TestCaseXmlRenderer(testPlan).toXml(xml, testCase));
   }


### PR DESCRIPTION
Fix for https://github.com/bazel-contrib/rules_jvm/issues/285

With a [ParameterizedTest](https://junit.org/junit5/docs/5.0.2/api/org/junit/jupiter/params/ParameterizedTest.html) it is possible to generate test case names with invalid XML characters. E.g.

```
@ParameterizedTest
@ValueSource(strings = {"Weird\bname"})
void testFoo(String input) {
    ...
}
```

The test case name is derived from the input string, which in this case contains an invalid XML char `\b`. When tools (like IDEs) try to parse the junit XML, they'll fail due to the invalid char.

Fix it by escaping test case names. It looks like [test suite names](https://junit.org/junit5/docs/5.0.3/api/org/junit/jupiter/api/DisplayName.html) could also contain invalid XML chars, so I'm escaping those as well.