### PR TITLE
refactor: remove runner attribute from create_jvm_test_suite

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -9,13 +9,6 @@ def _is_test(src, test_suffixes, test_suffixes_excludes):
             return True
     return False
 
-# If you modify this list, please also update the `_TEST_GENERATORS`
-# map in `java_test_suite.bzl`.
-_RUNNERS = [
-    "junit4",
-    "junit5",
-]
-
 _LIBRARY_ATTRS = [
     "data",
     "javacopts",
@@ -31,7 +24,6 @@ def create_jvm_test_suite(
         define_library,
         define_test,
         library_attributes = _LIBRARY_ATTRS,
-        runner = "junit4",
         deps = None,
         runtime_deps = [],
         tags = [],
@@ -64,15 +56,11 @@ def create_jvm_test_suite(
       define_library: A function that creates a `*_library` target.
       define_test: A function that creates a `*_test` target and returns the name of the created target.
         (See java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags for example use)
-      runner: The junit runner to use. Either "junit4" or "junit5".
       deps: The list of dependencies to use when compiling.
       runtime_deps: The list of runtime deps to use when running tests.
       tags: Tags to use for generated targets.
       size: Bazel test size
     """
-
-    if runner not in _RUNNERS:
-        fail("Unknown java_test_suite runner. Must be one of {}".format(_RUNNERS))
 
     # First, grab any interesting attrs
     library_attrs = {attr: kwargs[attr] for attr in library_attributes if attr in kwargs}

--- a/java/private/java_test_suite.bzl
+++ b/java/private/java_test_suite.bzl
@@ -81,7 +81,6 @@ def java_test_suite(
         define_library = _define_library,
         # Default to bazel's default test runner if we don't know what people want
         define_test = _TEST_GENERATORS.get(runner, _define_junit4_test),
-        runner = runner,
         deps = deps,
         runtime_deps = runtime_deps,
         size = size,

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/java_test_suite.bzl
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/suite_tags/java_test_suite.bzl
@@ -29,7 +29,6 @@ def java_test_suite(
         package = package,
         define_test = _define_junit5_test,
         define_library = _define_library,
-        runner = runner,
         duplicate_test_name = name,
         **kwargs
     )


### PR DESCRIPTION
In `create_jvm_test_suite.bzl`, the `runner` attribute is not utilised within the `define_test` function. By the time we reach the `create_jvm_test_suite` macro, this attribute is redundant because the specific test runner can be directly specified within the `define_test` function provided by the user. So, this PR removes references to the runner from the macro.