### PR TITLE
Allow JUnit5 runner to be extended

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ActualRunner.java
@@ -90,23 +90,23 @@ public class ActualRunner implements RunsTest {
     // We only allow for one level of nesting at the moment
     boolean enclosed = isRunWithEnclosed(testClass);
     List<DiscoverySelector> classSelectors =
-            enclosed
-                    ? new ArrayList<>()
-                    : Arrays.stream(testClass.getDeclaredClasses())
-                    .filter(clazz -> Modifier.isStatic(clazz.getModifiers()))
-                    .map(DiscoverySelectors::selectClass)
-                    .collect(Collectors.toList());
+        enclosed
+            ? new ArrayList<>()
+            : Arrays.stream(testClass.getDeclaredClasses())
+                .filter(clazz -> Modifier.isStatic(clazz.getModifiers()))
+                .map(DiscoverySelectors::selectClass)
+                .collect(Collectors.toList());
 
     classSelectors.add(DiscoverySelectors.selectClass(testClassName));
 
     LauncherDiscoveryRequestBuilder request =
-            LauncherDiscoveryRequestBuilder.request()
-                    .selectors(classSelectors)
-                    .configurationParameter(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, "true")
-                    .configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true")
-                    .configurationParameter(
-                            Constants.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME, "true")
-                    .filters(getFilters().toArray(new Filter[0]));
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(classSelectors)
+            .configurationParameter(LauncherConstants.CAPTURE_STDERR_PROPERTY_NAME, "true")
+            .configurationParameter(LauncherConstants.CAPTURE_STDOUT_PROPERTY_NAME, "true")
+            .configurationParameter(
+                Constants.EXTENSIONS_AUTODETECTION_ENABLED_PROPERTY_NAME, "true")
+            .filters(getFilters().toArray(new Filter[0]));
 
     return request.build();
   }
@@ -128,13 +128,13 @@ public class ActualRunner implements RunsTest {
     }
 
     List<String> includeEngines =
-            System.getProperty("JUNIT5_INCLUDE_ENGINES") == null
-                    ? null
-                    : Arrays.asList(System.getProperty("JUNIT5_INCLUDE_ENGINES").split(","));
+        System.getProperty("JUNIT5_INCLUDE_ENGINES") == null
+            ? null
+            : Arrays.asList(System.getProperty("JUNIT5_INCLUDE_ENGINES").split(","));
     List<String> excludeEngines =
-            System.getProperty("JUNIT5_EXCLUDE_ENGINES") == null
-                    ? null
-                    : Arrays.asList(System.getProperty("JUNIT5_EXCLUDE_ENGINES").split(","));
+        System.getProperty("JUNIT5_EXCLUDE_ENGINES") == null
+            ? null
+            : Arrays.asList(System.getProperty("JUNIT5_EXCLUDE_ENGINES").split(","));
     if (includeEngines != null) {
       filters.add(includeEngines(includeEngines));
     }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -52,6 +52,7 @@ public class JUnit5Runner {
     exit(systemExitToggle, 0);
   }
 
+  /** Returns an instance of RunsTest which handles creating and invoking the test runner */
   protected RunsTest getRunner() throws ReflectiveOperationException {
     Constructor<? extends RunsTest> constructor =
         Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -54,7 +54,7 @@ public class JUnit5Runner {
 
   protected RunsTest getRunner() throws ReflectiveOperationException {
     Constructor<? extends RunsTest> constructor =
-            Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();
+        Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();
     return constructor.newInstance();
   }
 

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/JUnit5Runner.java
@@ -19,6 +19,10 @@ public class JUnit5Runner {
       "com.github.bazel_contrib.contrib_rules_jvm.junit5.Java17SystemExitToggle";
 
   public static void main(String[] args) {
+    new JUnit5Runner().run();
+  }
+
+  public void run() {
     String testSuite = System.getProperty("bazel.test_suite");
 
     SystemExitToggle systemExitToggle = getSystemExitToggle();
@@ -33,9 +37,7 @@ public class JUnit5Runner {
     systemExitToggle.prevent();
 
     try {
-      Constructor<? extends RunsTest> constructor =
-          Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();
-      RunsTest runsTest = constructor.newInstance();
+      RunsTest runsTest = getRunner();
       if (!runsTest.run(testSuite)) {
         exit(systemExitToggle, 2);
       }
@@ -50,7 +52,13 @@ public class JUnit5Runner {
     exit(systemExitToggle, 0);
   }
 
-  private static SystemExitToggle getSystemExitToggle() {
+  protected RunsTest getRunner() throws ReflectiveOperationException {
+    Constructor<? extends RunsTest> constructor =
+            Class.forName(JUNIT5_RUNNER_CLASS).asSubclass(RunsTest.class).getConstructor();
+    return constructor.newInstance();
+  }
+
+  protected SystemExitToggle getSystemExitToggle() {
     // In Java 8 and lower, the first part of the version is a 1.
     // In Java 9 and higher, the first part of the version is the feature version.
     // Major versions of early Access builds have an "-ea" suffix.


### PR DESCRIPTION
I have a use case to use `SuiteLauncherDiscoveryRequestBuilder` instead of `LauncherDiscoveryRequestBuilder`. Refactoring the runner to allow extending Junit5Runner and ActualRunner to enable extending the runner to allow for that.