### PR TITLE
Gazelle: detect any directory with /test in path as test package

### DIFF
--- a/java/gazelle/private/java/java.go
+++ b/java/gazelle/private/java/java.go
@@ -21,7 +21,7 @@ func IsTestPackage(pkg string) bool {
 		}
 	}
 
-	return strings.Contains(pkg, "/test")
+	return strings.Contains(pkg, "/test/") || strings.HasSuffix(pkg, "/test")
 }
 
 // This list was derived from a script along the lines of:

--- a/java/gazelle/private/java/java_test.go
+++ b/java/gazelle/private/java/java_test.go
@@ -18,6 +18,8 @@ func TestIsTestPackage(t *testing.T) {
 		"src/test/java/com/example/myproject":          true,
 		"src/main/com/example/perftest":                false,
 		"test-utils/src/main/com/example/project":      false,
+		"foo/bar/test":                                 true,
+		"project1/testutils/src/main":                  false,
 	}
 
 	for pkg, want := range tests {


### PR DESCRIPTION
We have not very java-like structure in our monorepo:
<img width="275" alt="Screen Shot 2024-08-29 at 16 53 15" src="https://github.com/user-attachments/assets/03dfabef-b933-40cf-951a-8a2104dbd6ea">
So current func IsTestPackage doesn't detect our tests as tests and we have `found MULTIPLE results in rule index` error because of the same package in test classes.
We propose the fix, so files in packages like `//common/test` will also fit as test packages.