### PR TITLE
Bump lowest supported Java version to 8 in our build files

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -27,7 +27,7 @@ java_library(
     # available.
     javacopts = [
         "--release",
-        "8",
+        "11",
     ],
     deps = [
         # There must never be dependencies
@@ -52,11 +52,11 @@ java_library(
         ],
     ),
     javacopts = [
-        # Target Java 8, no matter which JDK we're on so that we
+        # Target Java 11, no matter which JDK we're on so that we
         # can be sure that `SecurityManager` is present, even if
         # someone rebuilds on a JDK that doesn't have it.
         "--release",
-        "8",
+        "11",
     ],
     resource_strip_prefix = package_name(),
     resources = ["META-INF/services/org.junit.jupiter.api.extension.Extension"],


### PR DESCRIPTION
Doing this prevents warnings about Java 8 being no longer supported when using a modern JDK and compiling our own supporting code.