### PR TITLE
allow passing empty 'package' to 'java_test_suite'

### DIFF
--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -34,7 +34,7 @@ def get_class_name(package, src, prefixes = []):
     # safe to add the class name. While `get_package_name` does
     # the right thing, the parameter passed by a user may not
     # so we shall check once we have `pkg` just to be safe.
-    pkg = package if package else get_package_name(prefixes)
+    pkg = package != None if package else get_package_name(prefixes)
     if len(pkg) and not pkg.endswith("."):
         pkg = pkg + "."
 

--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -34,7 +34,7 @@ def get_class_name(package, src, prefixes = []):
     # safe to add the class name. While `get_package_name` does
     # the right thing, the parameter passed by a user may not
     # so we shall check once we have `pkg` just to be safe.
-    pkg = package != None if package else get_package_name(prefixes)
+    pkg = package if package != None else get_package_name(prefixes)
     if len(pkg) and not pkg.endswith("."):
         pkg = pkg + "."
 


### PR DESCRIPTION
If for whatever reason one has test classes in the unnamed package, the current logic for detecting the full classname will return something like `src.test.java.FoobarTest` when you specify `package = ""` because of the truthiness test in `get_class_name`.