### PR TITLE
Test reporting name

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
@@ -33,18 +33,7 @@ class TestCaseXmlRenderer {
     decimalFormat.setRoundingMode(RoundingMode.HALF_UP);
 
     TestIdentifier id = test.getId();
-
-    String name;
-    if (test.isDynamic()) {
-      name = id.getDisplayName(); // [ordinal] name=value...
-    } else {
-      // Massage the name
-      name = id.getLegacyReportingName();
-      int index = name.indexOf('(');
-      if (index != -1) {
-        name = name.substring(0, index);
-      }
-    }
+    String name = id.getLegacyReportingName();
 
     xml.writeStartElement("testcase");
     xml.writeAttribute("name", escapeIllegalCharacters(name));

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
@@ -348,7 +348,7 @@ public class BazelJUnitOutputListenerTest {
     Node item = xml.getElementsByTagName("testcase").item(0);
     String testName = item.getAttributes().getNamedItem("name").getNodeValue();
 
-    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name", testName);
+    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name()]", testName);
   }
 
   @Test


### PR DESCRIPTION
fixes: #319 

The TestCaseXmlRenderer class reports displayName for tests marked as dynamic. In JUnit 5, all tests of typem TestTemplateDescriptor are considered dynamic, including tests annotated with @ParameterizedTest, @TestTemplate, @TestFactory, and @RepeatedTest. Assigning a displayName to these tests is optional, and there is no enforcement of unique display names.

To ensure consistent and unique test identification across tools, use the legacy reporting name instead of displayName for test reporting:
1. Test names will be identical to those reported by Bazel's native TestRunListener for Vintage tests.
2. JUnit 5 test names will include parentheses, which is reasonable because JUnit 5 allows template-based tests with the same method name but different arguments.