### PR TITLE
fix: BazelJUnitOutputListener logging xml output on suite-level failures

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
@@ -264,7 +264,6 @@ public class BazelJUnitOutputListener implements TestExecutionListener, Closeabl
         .collect(Collectors.toList());
   }
 
-
   @Override
   public void reportingEntryPublished(TestIdentifier testIdentifier, ReportEntry entry) {
     getResult(testIdentifier).addReportEntry(entry);

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListener.java
@@ -204,18 +204,23 @@ public class BazelJUnitOutputListener implements TestExecutionListener, Closeabl
           TestData suite = suiteAndTests.getKey();
           List<TestData> tests = suiteAndTests.getValue();
           if (suite.getResult().getStatus() != TestExecutionResult.Status.SUCCESSFUL) {
-            // If a test suite fails, all its tests must be included in the XML output with the same result as the
-            // suite, since the XML format does not support marking a suite as failed. This aligns with Bazel's
+            // If a test suite fails, all its tests must be included in the XML output with the same
+            // result as the
+            // suite, since the XML format does not support marking a suite as failed. This aligns
+            // with Bazel's
             // XmlWriter for JUnitRunner.
-            testPlan.getChildren(suite.getId()).forEach(testIdentifier -> {
-              TestData test = results.get(testIdentifier.getUniqueIdObject());
-              if (test == null) {
-                // add test to results.
-                test = getResult(testIdentifier);
-                tests.add(test);
-              }
-              test.mark(suite.getResult());
-            });
+            testPlan
+                .getChildren(suite.getId())
+                .forEach(
+                    testIdentifier -> {
+                      TestData test = results.get(testIdentifier.getUniqueIdObject());
+                      if (test == null) {
+                        // add test to results.
+                        test = getResult(testIdentifier);
+                        tests.add(test);
+                      }
+                      test.mark(suite.getResult());
+                    });
           }
           new TestSuiteXmlRenderer(testPlan).toXml(xml, suite, tests);
         }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
@@ -11,9 +11,15 @@ import org.junit.platform.engine.UniqueId;
 public class StubbedTestDescriptor implements TestDescriptor {
 
   private final UniqueId uniqueId;
+  private final Type type;
 
   public StubbedTestDescriptor(UniqueId uniqueId) {
+    this(uniqueId, Type.TEST);
+  }
+
+  public StubbedTestDescriptor(UniqueId uniqueId, Type type) {
     this.uniqueId = uniqueId;
+    this.type = type;
   }
 
   @Override
@@ -68,7 +74,7 @@ public class StubbedTestDescriptor implements TestDescriptor {
 
   @Override
   public Type getType() {
-    return Type.TEST;
+    return type;
   }
 
   @Override

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
@@ -1,6 +1,5 @@
 package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 
-import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
@@ -263,11 +263,18 @@ public class BazelJUnitOutputListenerTest {
   }
 
   @Test
-  void testSuiteError(@TempDir Path tempDir) throws ParserConfigurationException, IOException, SAXException {
-    TestIdentifier root = TestIdentifier.from(new StubbedTestDescriptor(UniqueId.parse("[engine:mocked]")));
-    TestIdentifier suiteIdentifier = TestIdentifier.from(
-            new StubbedTestDescriptor(UniqueId.parse("[engine:mocked]/[class:ExampleTest]"), TestDescriptor.Type.CONTAINER));
-    TestData suite = new TestData(suiteIdentifier).started()
+  void testSuiteError(@TempDir Path tempDir)
+      throws ParserConfigurationException, IOException, SAXException {
+    TestIdentifier root =
+        TestIdentifier.from(new StubbedTestDescriptor(UniqueId.parse("[engine:mocked]")));
+    TestIdentifier suiteIdentifier =
+        TestIdentifier.from(
+            new StubbedTestDescriptor(
+                UniqueId.parse("[engine:mocked]/[class:ExampleTest]"),
+                TestDescriptor.Type.CONTAINER));
+    TestData suite =
+        new TestData(suiteIdentifier)
+            .started()
             .mark(TestExecutionResult.failed(new RuntimeException("test suite error")));
     TestPlan testPlan = Mockito.mock(TestPlan.class);
 
@@ -282,11 +289,13 @@ public class BazelJUnitOutputListenerTest {
       listener.testPlanExecutionStarted(testPlan);
       listener.executionStarted(root);
       listener.executionStarted(suiteIdentifier);
-      listener.executionFinished(suiteIdentifier, TestExecutionResult.failed(new RuntimeException("test suite error")));
+      listener.executionFinished(
+          suiteIdentifier, TestExecutionResult.failed(new RuntimeException("test suite error")));
       listener.executionFinished(root, TestExecutionResult.successful());
     }
 
-    Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlPath.toFile());
+    Document document =
+        DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(xmlPath.toFile());
     document.getDocumentElement().normalize();
 
     NodeList testsuiteList = document.getDocumentElement().getElementsByTagName("testsuite");
@@ -299,7 +308,7 @@ public class BazelJUnitOutputListenerTest {
     assertEquals(2, testcaseList.getLength());
 
     for (int i = 0; i < testcaseList.getLength(); i++) {
-        Element testcase = (Element) testcaseList.item(i);
+      Element testcase = (Element) testcaseList.item(i);
       assertNotNull(getChild("failure", testcase));
     }
   }


### PR DESCRIPTION
fixes: #327 

1. Updated code to propagate the test suite failure to each test case.
2. The test suite failure will be propagated to each child node, even if the test is not executed.
3. Additionally, this change fixes the bug introduced in #300, which incorrectly logged the test_suite as a testcase and logged incorrect values for the "tests" attribute in the <testsuite> node.