### PR TITLE
Add Time Attribute to TestSuite

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
@@ -4,16 +4,15 @@ import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.escapeIl
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeTextElement;
 
 import java.net.InetAddress;
-import java.time.format.DateTimeFormatter;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Locale;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
-
 import org.junit.platform.launcher.TestPlan;
 
 class TestSuiteXmlRenderer {
@@ -36,7 +35,7 @@ class TestSuiteXmlRenderer {
     DecimalFormat decimalFormat = new DecimalFormat("#.##", new DecimalFormatSymbols(Locale.ROOT));
     /* @Nullable */ Duration maybeDuration = suite.getDuration();
     Duration duration =
-            maybeDuration == null ? Duration.between(suite.getStarted(), Instant.now()) : maybeDuration;
+        maybeDuration == null ? Duration.between(suite.getStarted(), Instant.now()) : maybeDuration;
     xml.writeAttribute("time", decimalFormat.format(duration.toMillis() / 1000f));
 
     int errors = 0;

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
@@ -5,9 +5,15 @@ import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeTex
 
 import java.net.InetAddress;
 import java.time.format.DateTimeFormatter;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
+import java.util.Locale;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
+
 import org.junit.platform.launcher.TestPlan;
 
 class TestSuiteXmlRenderer {
@@ -26,6 +32,12 @@ class TestSuiteXmlRenderer {
     xml.writeAttribute("timestamp", DateTimeFormatter.ISO_INSTANT.format(suite.getStarted()));
     xml.writeAttribute("hostname", getHostname());
     xml.writeAttribute("tests", String.valueOf(tests.size()));
+
+    DecimalFormat decimalFormat = new DecimalFormat("#.##", new DecimalFormatSymbols(Locale.ROOT));
+    /* @Nullable */ Duration maybeDuration = suite.getDuration();
+    Duration duration =
+            maybeDuration == null ? Duration.between(suite.getStarted(), Instant.now()) : maybeDuration;
+    xml.writeAttribute("time", decimalFormat.format(duration.toMillis() / 1000f));
 
     int errors = 0;
     int failures = 0;


### PR DESCRIPTION
This PR introduces a time attribute to the TestSuite to track the total execution time of the test suite.  Similar bazel's Junit4Listener.