### PR TITLE
extend package prefixes with ".dev"

### DIFF
--- a/java/private/package.bzl
+++ b/java/private/package.bzl
@@ -1,5 +1,5 @@
 # Common package prefixes, in the order we want to check for them
-_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.", ".me.")
+_PREFIXES = (".com.", ".org.", ".net.", ".io.", ".ai.", ".co.", ".me.", ".dev.")
 
 # By default bazel computes the name of test classes based on the
 # standard Maven directory structure, which we may not always use,


### PR DESCRIPTION
With a dev TLD in the package namespace, tests caused an error like this:

Class not found: [dev.THEDOMAIN.PROJECT.src.test.java.dev.THEDOMAIN.PROJECT.SomeTest]

This addition fixes it and is workable without using the undocumented "package_prefixes = [...]" in the java_test_suite rule.