### PR TITLE
chore: Avoid modifying deps argument

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -87,7 +87,7 @@ def create_jvm_test_suite(
             **library_attrs
         )
         if not _contains_label(deps or [], lib_dep_label):
-            deps.append(lib_dep_label)
+            deps = deps + [lib_dep_label]
 
     tests = []
 


### PR DESCRIPTION
It is not great to modify the passed-in `deps` argument because users might use the same variable in a later macro/rule invocation but find it has been tainted.