### PR TITLE
Use SafeXml to write CData from throwable message

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/SafeXml.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/SafeXml.java
@@ -40,10 +40,17 @@ public class SafeXml {
 
     xml.writeStartElement(elementName);
 
+    writeCData(xml, text);
+    xml.writeEndElement();
+  }
+
+  public static void writeCData(XMLStreamWriter xml, String text) throws XMLStreamException {
+    if (text == null) {
+      return;
+    }
     // If the text content contains a cdata end tag, then the generated xml won't
     // be parseable. Replace the end tag with a new cdata section, so everything
     // works as expected
     xml.writeCData(escapeIllegalCharacters(text.replace("]]>", "]]]]><![CDATA[>")));
-    xml.writeEndElement();
   }
 }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
@@ -1,6 +1,7 @@
 package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.escapeIllegalCharacters;
+import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeCData;
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeTextElement;
 
 import java.io.PrintWriter;
@@ -102,6 +103,6 @@ class TestCaseXmlRenderer {
     StringWriter stringWriter = new StringWriter();
     throwable.printStackTrace(new PrintWriter(stringWriter));
 
-    xml.writeCData(escapeIllegalCharacters(stringWriter.toString()));
+    writeCData(xml, stringWriter.toString());
   }
 }


### PR DESCRIPTION
Use SafeXml to write CDATA from throwable message. 
Sample stacktrace which generates unaparseable xml.
```
org.opentest4j.AssertionFailedError: expected: <Optional[[localhost]]> but was: <Optional.empty>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:182)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:177)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1145)
```
