### PR TITLE
Don't add -Djava.security.manager=allow property

### DIFF
--- a/java/private/junit5.bzl
+++ b/java/private/junit5.bzl
@@ -91,12 +91,9 @@ def java_junit5_test(
     if exclude_engines:
         jvm_flags = jvm_flags + ["-DJUNIT5_EXCLUDE_ENGINES=%s" % ",".join(exclude_engines)]
 
-    security_manager_flag_seen = False
-    for flag in jvm_flags:
-        if flag.startswith("-Djava.security.manager="):
-            security_manager_flag_seen = True
-    if not security_manager_flag_seen:
-        jvm_flags = jvm_flags + ["-Djava.security.manager=allow"]
+    # Note: Security manager flag is no longer automatically added
+    # The security manager is deprecated and removed in Java 24+ (JEP 411)
+    # Users can manually add -Djava.security.manager=allow to jvm_flags if needed for older Java versions
 
     java_test(
         name = name,


### PR DESCRIPTION
This property causes this failure in JDK24+
```
Error occurred during initialization of VM
java.lang.Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.
	at java.lang.System.initPhase3(java.base@24.0.1/System.java:1947)
```

Ideally I would have detected JVM version like https://github.com/bazelbuild/rules_java/commit/b3a0580e0a9a6b8b28b611c7dd6164c06b279539 but I didn't see an obvious way to do this.