### PR TITLE
Explicitly load `java_import` from `@rules_java`

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library")
 load("//java/private:artifact.bzl", "artifact")
 
 # We want to be able to compile the test runner, but we don't want to


### PR DESCRIPTION
Bazel 8+ requires explicit loading of `java_import` as Java rules moved from Bazel core to `@rules_java`.