### PR TITLE
build(release): update release process for bzlmod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,5 @@
-# Cut a release whenever a new tag is pushed to the repo.
-# You should use an annotated tag, like `git tag -a v1.2.3`
-# and put the release notes into the commit message for the tag.
+# This action cuts a GitHub release whenever a new tag is pushed to the repo.
+# See CONTRIBUTING.md for a releasing guide.
 name: Release
 
 on:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -1,36 +1,25 @@
 #!/usr/bin/env bash
 set -eufo pipefail
 
+# Called by .github/workflows/release.yml to generate release notes.
+
 # Set by GH actions, see
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
-TAG=${GITHUB_REF_NAME}
+TAG=${GITHUB_REF_NAME} # e.g. v1.2.3
+VERSION=${TAG#v}       # e.g. 1.2.3
 # The prefix is chosen to match what GitHub generates for source archives
 PREFIX="rules_jvm-${TAG:1}"
 ARCHIVE="rules_jvm-$TAG.tar.gz"
-git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
-SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
+git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip >"$ARCHIVE"
 
-cat << EOF
-WORKSPACE snippet:
+cat <<EOF
+\`contrib_rules_jvm\` only supports \`bzlmod\`-enabled builds
+
+## Module setup
+
+In your \`MODULE.bazel\`:
+
 \`\`\`starlark
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "contrib_rules_jvm",
-    sha256 = "${SHA}",
-    strip_prefix = "${PREFIX}",
-    url = "https://github.com/bazel-contrib/rules_jvm/releases/download/${TAG}/${ARCHIVE}",
-)
-
-# Fetches the contrib_rules_jvm dependencies.
-# If you want to have a different version of some dependency,
-# you should fetch it *before* calling this.
-load("@contrib_rules_jvm//:repositories.bzl", "contrib_rules_jvm_deps")
-
-contrib_rules_jvm_deps()
-
-# Now ensure that the downloaded deps are properly configured
-load("@contrib_rules_jvm//:setup.bzl", "contrib_rules_jvm_setup")
-
-contrib_rules_jvm_setup()
+bazel_dep(name = "contrib_rules_jvm", version = "${VERSION}")
 \`\`\`
 EOF

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,10 @@ point to the `rules_jvm` folder.
 
 ## Releasing
 
-1. Determine the next release version, following semver if possible/
-2. Tag the repo and push it (or create a tag in GH UI).
-3. Watch the automation run on GitHub actions.
+1. Determine the next release version, following semver if possible.
+2. Tag the repo and push it (e.g. `git tag v1.2.3`), or create a tag in GitHub UI.
+3. Watch the automation run via the [GitHub action](.github/workflows/release.yml).
+4. Once the GitHub release has been created, you can manually edit it.
+5. Update the Bazel Central Registry's contrib_rules_jvm module, as in [this PR][]
 
+[this PR]: https://github.com/bazelbuild/bazel-central-registry/pull/3770


### PR DESCRIPTION
Updates the pre-generated release notes to be bzlmod friendly, and adds
a note about submitting to the Bazel Central Registry.

Based on the process I ended up using for v0.29.0