### PR TITLE
fix: support nested classes properly

### DIFF
--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$First.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$First.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$First" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.0">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$First" time="0.0"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest$First
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.001">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth" time="0.001"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third$Fourth$Fifth
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.0">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth" time="0.0"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third$Fourth
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.0">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third" time="0.0"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.0">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second" time="0.0"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest.xml
+++ b/comparative-tests/build/test-results/test/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest" tests="1" skipped="0" failures="0" errors="0" timestamp="2025-07-23T17:23:19" hostname="MacBook-Pro.local" time="0.0">
+  <properties/>
+  <testcase name="shouldBeExecuted()" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest" time="0.0"/>
+  <system-out><![CDATA[>>>> Executed test in NestedClassesTest
+]]></system-out>
+  <system-err><![CDATA[]]></system-err>
+</testsuite>

--- a/comparative-tests/src/test/java/com/github/bazel_contrib/contrib_rules_jvm/comparative/NestedClassesTest.java
+++ b/comparative-tests/src/test/java/com/github/bazel_contrib/contrib_rules_jvm/comparative/NestedClassesTest.java
@@ -1,6 +1,5 @@
-package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+package com.github.bazel_contrib.contrib_rules_jvm.comparative;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +12,6 @@ public class NestedClassesTest {
   }
 
   @Nested
-  @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
   class Second {
     @Test
     public void shouldBeExecuted() {
@@ -21,7 +19,6 @@ public class NestedClassesTest {
     }
 
     @Nested
-    @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
     class Third {
       @Test
       public void shouldBeExecuted() {
@@ -29,7 +26,6 @@ public class NestedClassesTest {
       }
 
       @Nested
-      @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
       class Fourth {
         @Test
         public void shouldBeExecuted() {
@@ -37,7 +33,6 @@ public class NestedClassesTest {
         }
 
         @Nested
-        @SuppressFBWarnings("SIC_INNER_SHOULD_BE_STATIC")
         class Fifth {
           @Test
           public void shouldBeExecuted() {

--- a/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth.xml
+++ b/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd" version="3.0" name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth" time="0.001" tests="5" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.specification.version" value="11"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="user.country" value="US"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="java.version.date" value="2024-07-16"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="path.separator" value=":"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="java.version" value="11.0.24"/>
+    <property name="os.arch" value="aarch64"/>
+    <property name="native.encoding" value="UTF-8"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="java.class.version" value="55.0"/>
+  </properties>
+  <testcase name="shouldBeExecuted" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest" time="0.0">
+    <system-out><![CDATA[>>>> Executed test in NestedClassesTest
+]]></system-out>
+  </testcase>
+  <testcase name="shouldBeExecuted" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second" time="0.0">
+    <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second
+]]></system-out>
+  </testcase>
+  <testcase name="shouldBeExecuted" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third" time="0.0">
+    <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third
+]]></system-out>
+  </testcase>
+  <testcase name="shouldBeExecuted" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth" time="0.0">
+    <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third$Fourth
+]]></system-out>
+  </testcase>
+  <testcase name="shouldBeExecuted" classname="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth$Fifth" time="0.001">
+    <system-out><![CDATA[>>>> Executed test in NestedClassesTest$Second$Third$Fourth$Fifth
+]]></system-out>
+  </testcase>
+</testsuite>

--- a/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth.xml
+++ b/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd" version="3.0" name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third$Fourth" time="0.002" tests="0" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.specification.version" value="11"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="user.country" value="US"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="java.version.date" value="2024-07-16"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="path.separator" value=":"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="java.version" value="11.0.24"/>
+    <property name="os.arch" value="aarch64"/>
+    <property name="native.encoding" value="UTF-8"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="java.class.version" value="55.0"/>
+  </properties>
+</testsuite>

--- a/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third.xml
+++ b/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd" version="3.0" name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second$Third" time="0.003" tests="0" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.specification.version" value="11"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="user.country" value="US"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="java.version.date" value="2024-07-16"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="path.separator" value=":"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="java.version" value="11.0.24"/>
+    <property name="os.arch" value="aarch64"/>
+    <property name="native.encoding" value="UTF-8"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="java.class.version" value="55.0"/>
+  </properties>
+</testsuite>

--- a/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second.xml
+++ b/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd" version="3.0" name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest$Second" time="0.004" tests="0" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.specification.version" value="11"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="user.country" value="US"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="java.version.date" value="2024-07-16"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="path.separator" value=":"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="java.version" value="11.0.24"/>
+    <property name="os.arch" value="aarch64"/>
+    <property name="native.encoding" value="UTF-8"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="java.class.version" value="55.0"/>
+  </properties>
+</testsuite>

--- a/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest.xml
+++ b/comparative-tests/target/surefire-reports/TEST-com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report-3.0.xsd" version="3.0" name="com.github.bazel_contrib.contrib_rules_jvm.comparative.NestedClassesTest" time="0.004" tests="0" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.specification.version" value="11"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.vm.specification.version" value="11"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="user.country" value="US"/>
+    <property name="jdk.debug" value="release"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="user.language" value="en"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="java.version.date" value="2024-07-16"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vm.compressedOopsMode" value="Zero based"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="path.separator" value=":"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="java.version" value="11.0.24"/>
+    <property name="os.arch" value="aarch64"/>
+    <property name="native.encoding" value="UTF-8"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="java.class.version" value="55.0"/>
+  </properties>
+</testsuite>

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
@@ -12,14 +12,20 @@ public class StubbedTestDescriptor implements TestDescriptor {
 
   private final UniqueId uniqueId;
   private final Type type;
+  private final Optional<TestDescriptor> parent;
 
   public StubbedTestDescriptor(UniqueId uniqueId) {
     this(uniqueId, Type.TEST);
   }
 
   public StubbedTestDescriptor(UniqueId uniqueId, Type type) {
+    this(uniqueId, type, null);
+  }
+
+  public StubbedTestDescriptor(UniqueId uniqueId, Type type, TestDescriptor parent) {
     this.uniqueId = uniqueId;
     this.type = type;
+    this.parent = Optional.ofNullable(parent);
   }
 
   @Override
@@ -44,12 +50,12 @@ public class StubbedTestDescriptor implements TestDescriptor {
 
   @Override
   public Optional<TestDescriptor> getParent() {
-    return Optional.empty();
+    return parent;
   }
 
   @Override
   public void setParent(TestDescriptor parent) {
-    // Do nothin
+    // Do nothing
   }
 
   @Override


### PR DESCRIPTION
Previously if you had deeply nested classes the BazelJUnitOutputListener would throw an exception. In JUnit5 TestExecutionListeners are not expected to throw exceptions and any exception just gets swallowed and logged as a warning. This would cause cases where an exception was thrown to output no test results and result in a successful test run even though there was a failure in the listener itself. The new logic attempts to get the closest parent segment that is a class type. This doesn't match the way things like gradle will output test XML but solves the problem with nested classes while keeping the output similar.

In terms of output this actually fixes an issue that is visible in the NestedClassesTest today, where the Second nested classes function result gets grouped into the outer class while the static First classes function result appears in a separate group as shown below:

```
NestedClassesTest
  shouldBeExecuted
  shouldBeExecuted
NestedClassesTest$First
  shouldBeExecuted
```

With the changes the grouping is fixed as shown below:

```
NestedClassesTest
  shouldBeExecuted
NestedClassesTest$First
  shouldBeExecuted
NestedClassesTest$Second
  shouldBeExecuted
NestedClassesTest$Second$Third
  shouldBeExecuted
NestedClassesTest$Second$Third$Fourth
  shouldBeExecuted
NestedClassesTest$Second$Third$Fourth$Fifth
  shouldBeExecuted
```

These groups appear unordered in UI like IntelliJ which isn't ideal, but these changes closely align with how things are done today, while avoiding just silently passing with no test output if you take this version of the NestedClassesTest and run it using the previous BazelJUnitOutputListener code.