### PR TITLE
fix: do not rely on method source to determine the class parent.

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/StubbedTestDescriptor.java
@@ -12,6 +12,7 @@ public class StubbedTestDescriptor implements TestDescriptor {
 
   private final UniqueId uniqueId;
   private final Type type;
+  private final Optional<TestSource> source;
   private final Optional<TestDescriptor> parent;
 
   public StubbedTestDescriptor(UniqueId uniqueId) {
@@ -22,9 +23,15 @@ public class StubbedTestDescriptor implements TestDescriptor {
     this(uniqueId, type, null);
   }
 
-  public StubbedTestDescriptor(UniqueId uniqueId, Type type, TestDescriptor parent) {
+  public StubbedTestDescriptor(UniqueId uniqueId, Type type, TestSource source) {
+    this(uniqueId, type, source, null);
+  }
+
+  public StubbedTestDescriptor(
+      UniqueId uniqueId, Type type, TestSource source, TestDescriptor parent) {
     this.uniqueId = uniqueId;
     this.type = type;
+    this.source = Optional.ofNullable(source);
     this.parent = Optional.ofNullable(parent);
   }
 
@@ -45,7 +52,7 @@ public class StubbedTestDescriptor implements TestDescriptor {
 
   @Override
   public Optional<TestSource> getSource() {
-    return Optional.empty();
+    return source;
   }
 
   @Override


### PR DESCRIPTION
Cucumber tests do not always have a method source. Looking into gradle and maven, they both handle this differently. It turns out that gradle actually doesn't work for certain cucumber cases, as their parent class finder logic only returns parents that do not have the same class source information at the test itself. Maven actually finds the first parent class that is a container. This fix attempts to simplify the logic while working for other types of test sources.

TODO: Add cucumber tests to comparative and the junit5 tests.