### PR TITLE
fix: kotlin names and cucumber tests

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/PatternFilter.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/PatternFilter.java
@@ -17,6 +17,10 @@ import org.junit.platform.launcher.PostDiscoveryFilter;
  * class name and the method name.
  */
 public class PatternFilter implements PostDiscoveryFilter {
+  // Kotlin allows methods to have string names. These can include (), {}, *, +, ?, ^, $, and |.
+  // We don't include | in the escape logic because IntelliJ will add it to the filter
+  // when running test classes that contain nested classes.
+  private static final Pattern SPECIAL_CHAR_PATTERN = Pattern.compile("[(){}*+?^$]");
 
   private final String rawPattern;
   private final Predicate<String> pattern;
@@ -38,8 +42,16 @@ public class PatternFilter implements PostDiscoveryFilter {
       return FilterResult.included("Including container: " + object.getDisplayName());
     }
 
-    if (!object.getSource().isPresent()) {
-      return FilterResult.excluded("Skipping a test without a source: " + object.getDisplayName());
+    // Special test frameworks like cucumber do not have sources for their tests.
+    // Find the first parent with a source and apply the filter to that.
+    // This lets running individual tests in IDEs like IntelliJ work while also
+    // running all tests without sources when the '.*' pattern is set.
+    while (!object.getSource().isPresent()) {
+      object = object.getParent().orElse(null);
+      if (object == null) {
+        return FilterResult.excluded(
+            "Skipping a test without a source: " + object.getDisplayName());
+      }
     }
 
     TestSource source = object.getSource().get();
@@ -92,8 +104,24 @@ public class PatternFilter implements PostDiscoveryFilter {
         .collect(Collectors.joining("|"));
   }
 
-  /** Appends '$' to patterns like "class#method" or "#method", unless already done. */
+  /**
+   * Escapes specific regex special characters and appends '$' to patterns like "class#method" or
+   * "#method" when needed
+   */
   private static String ensureExactMethodName(String pattern) {
-    return pattern.matches(".*#.*[^$]$") ? pattern + '$' : pattern;
+    boolean matchesEnd = pattern.endsWith("$");
+    if (matchesEnd) {
+      pattern = pattern.substring(0, pattern.length() - 1);
+    }
+
+    // Escape the special characters
+    pattern = SPECIAL_CHAR_PATTERN.matcher(pattern).replaceAll("\\\\$0");
+
+    // Add $ back if it was there originally or add it if needed
+    if (matchesEnd || pattern.matches(".*#.*[^$]$")) {
+      pattern = pattern + '$';
+    }
+
+    return pattern;
   }
 }

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestCaseXmlRenderer.java
@@ -39,12 +39,7 @@ class TestCaseXmlRenderer {
     if (test.isDynamic()) {
       name = id.getDisplayName(); // [ordinal] name=value...
     } else {
-      // Massage the name
       name = id.getLegacyReportingName();
-      int index = name.indexOf('(');
-      if (index != -1) {
-        name = name.substring(0, index);
-      }
     }
 
     xml.writeStartElement("testcase");

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
@@ -439,7 +439,7 @@ public class BazelJUnitOutputListenerTest {
     Node item = xml.getElementsByTagName("testcase").item(0);
     String testName = item.getAttributes().getNamedItem("name").getNodeValue();
 
-    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name", testName);
+    assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name()]", testName);
   }
 
   @Test

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/FilteringTest.java
@@ -138,8 +138,7 @@ public class FilteringTest {
 
   @Test
   public void shouldIncludeATestMethodIfTheFilterIsJustTheClassName() {
-    PatternFilter filter =
-        new PatternFilter(JUnit5StyleTest.class.getName().replace("$", "\\$") + "#");
+    PatternFilter filter = new PatternFilter(JUnit5StyleTest.class.getName() + "#");
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());
@@ -156,8 +155,7 @@ public class FilteringTest {
 
   @Test
   public void shouldIncludeANestedTestMethodIfTheFilterIsJustTheNestedClassName() {
-    PatternFilter filter =
-        new PatternFilter(JUnit5StyleTest.NestedTest.class.getName().replace("$", "\\$") + "#");
+    PatternFilter filter = new PatternFilter(JUnit5StyleTest.NestedTest.class.getName() + "#");
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertFalse(testResult.included(), "method in enclosing class should not be matched");
@@ -177,9 +175,27 @@ public class FilteringTest {
     PatternFilter filter =
         new PatternFilter(
             String.join(
-                ",",
-                JUnit5StyleTest.class.getName().replace("$", "\\$"),
-                JUnit5StyleTest.NestedTest.class.getName().replace("$", "\\$")));
+                "|", JUnit5StyleTest.class.getName(), JUnit5StyleTest.NestedTest.class.getName()));
+
+    FilterResult testResult = filter.apply(testMethodTestDescriptor);
+    assertTrue(testResult.included());
+
+    FilterResult dynamicTestResult = filter.apply(testTemplateTestDescriptor);
+    assertTrue(dynamicTestResult.included());
+
+    FilterResult siblingTestResult = filter.apply(siblingTestMethodTestDescriptor);
+    assertTrue(siblingTestResult.included());
+
+    FilterResult nestedTestResult = filter.apply(nestedTestMethodTestDescriptor);
+    assertTrue(nestedTestResult.included());
+  }
+
+  @Test
+  public void shouldIncludeMultipleTestMethodsIfTheFilterComprisesMultipleClassNamesWithCommas() {
+    PatternFilter filter =
+        new PatternFilter(
+            String.join(
+                ",", JUnit5StyleTest.class.getName(), JUnit5StyleTest.NestedTest.class.getName()));
 
     FilterResult testResult = filter.apply(testMethodTestDescriptor);
     assertTrue(testResult.included());


### PR DESCRIPTION
There are two main changes in this PR.

The first is to support special cases like cucumber tests where the method itself doesn't have a Source object. This is because the tests come from the feature files rather than an actual source file. Instead of just skipping such tests we find the first parent with a source. This allows running individual tests via intelliJ to still work when the cucumber test class is being run.

The second change allows regex specific characters to work with the PatternFilter. This is required when kotlin names functions like `method() succeeds` and `method() fails` which currently causes duplicates in the XML report. Instead of massaging the name to remove everything after a ( is found, we now handle such characters properly in the filter code. This change does exclude . from the escaping because intelliJ separates class and methods when running individual tests with a . instead of #. This means we will potentially over execute tests but it's better to ensure the desired test is run than to not run anything.

Note: If kotlin support is added the FilteringTests should be updated to include special character function names to improve the test coverage.