### PR TITLE
create_jvm_test_suite: fail on empty tests list

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -124,7 +124,7 @@ def create_jvm_test_suite(
     if not tests:
         # test_suite with tests=[] would create a suite containing ALL tests in current package
         # which would be confusing
-        fail("create_jvm_test_suite tests list is empty, do test files follow test_suffixes pattern?")
+        fail("No tests found for suite '{}'. Do test files match 'test_suffixes'?".format(name))
 
     native.test_suite(
         name = name,


### PR DESCRIPTION
`native.test_suite` will treat empty tests list as all tests in package https://bazel.build/reference/be/general#test_suite.tests which can be confusing, and likely pointing to a bug if `test_suffixes` or test file names, so failing instead makes sense