### PR TITLE
create_jvm_test_suite: allow multiple suites to use same test source

### DIFF
--- a/java/private/create_jvm_test_suite.bzl
+++ b/java/private/create_jvm_test_suite.bzl
@@ -122,7 +122,7 @@ def create_jvm_test_suite(
 
     for src in test_srcs:
         suffix = src.rfind(".")
-        test_name = src[:suffix]
+        test_name = "%s-%s" % (name, src[:suffix])
         test_class = get_class_name(package, src, package_prefixes)
 
         test_name = define_test(


### PR DESCRIPTION
Currently `test_name` per test source doesn't include `create_jvm_test_suite.name`, so multiple suites in same package would conflict if they share test sources.

Multiple suites per test source could be useful to test multiple configurations: different env var, deps, or other parameters.