### PR TITLE
[gazelle] Fix 30s hang on javaparser shutdown; avoid GOAWAY noise

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/LifecycleService.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/LifecycleService.java
@@ -9,6 +9,23 @@ public class LifecycleService extends LifecycleGrpc.LifecycleImplBase {
 
   @Override
   public void shutdown(ShutdownRequest request, StreamObserver<ShutdownResponse> responseObserver) {
-    System.exit(0);
+    // Reply to the RPC so the client doesn't block waiting for a response.
+    try {
+      responseObserver.onNext(ShutdownResponse.newBuilder().build());
+      responseObserver.onCompleted();
+    } finally {
+      // Exit on a separate thread shortly after completing the response, to allow gRPC
+      // to flush frames and the client to process the response without waiting on shutdown.
+      new Thread(
+              () -> {
+                try {
+                  Thread.sleep(50);
+                } catch (InterruptedException ignored) {
+                }
+                System.exit(0);
+              },
+              "LifecycleShutdownExit")
+          .start();
+    }
   }
 }


### PR DESCRIPTION
The hang happened at shutdown because the server called `System.exit(0)` without replying to the `Lifecycle.Shutdown` RPC. The gRPC server then waited up to 30s with an in-flight call. Closing the client socket immediately would produce a (benign) “Broken pipe” GOAWAY stacktrace.

This change results in far faster shutdown of the gRPC server.