### PR TITLE
[gazelle] update gazelle readme to make tables readable

### DIFF
--- a/java/gazelle/README.md
+++ b/java/gazelle/README.md
@@ -140,7 +140,7 @@ The following directives specific to the Java extension are recognized:
 | Sourceset root explicitly marks a directory as the root of a sourceset. This provides a clear override to the auto-detection algorithm. Example: `# gazelle:java_sourceset_root my/custom/src` |
 | java_strip_resources_prefix                       | none                                     |
 | Strip resources prefix overrides the path-stripping behavior for resources. This is a direct way to specify the resource_strip_prefix for all resources in a directory. Example: `# gazelle:java_strip_resources_prefix my/data/config` |
-| java_include_binary                               | True                                     |
+| java_generate_binary                              | True                                     |
 | Controls if the generator adds `java_binary` targets to the build file. If set False, no `java_binary` targets are generated for the directories, defaults to True. |
 
 ## Troubleshooting


### PR DESCRIPTION
The table syntax for the Github markdown is much more limited than the table syntax for the generated docs. So fix the Gazelle Readme so the docs appear as readable. 

Add the  sourceset root, strip resources prefix and include binary directives. in the documentation.