### PR TITLE
Add a test case for paths like `src/main/com/example/test` and update IsTestPackage to handle it.

### DIFF
--- a/java/gazelle/private/java/java.go
+++ b/java/gazelle/private/java/java.go
@@ -19,6 +19,9 @@ func IsTestPackage(pkg string) bool {
 		if strings.HasSuffix(strings.ToLower(firstDir), "test") {
 			return true
 		}
+		if strings.HasSuffix(strings.ToLower(firstDir), "main") {
+			return false
+		}
 	}
 
 	return strings.Contains(pkg, "/test/") || strings.HasSuffix(pkg, "/test")

--- a/java/gazelle/private/java/java_test.go
+++ b/java/gazelle/private/java/java_test.go
@@ -16,6 +16,7 @@ func TestIsTestPackage(t *testing.T) {
 		"project1/src/integrationTest/more":            true,
 		"src/main/java/com/example/myproject":          false,
 		"src/test/java/com/example/myproject":          true,
+		"src/main/com/example/test":                    false,
 		"src/main/com/example/perftest":                false,
 		"test-utils/src/main/com/example/project":      false,
 		"foo/bar/test":                                 true,


### PR DESCRIPTION
Paths like this were previously added to `java_test_suite` instead of `java_library`.