### PR TITLE
chore: update aspect_bazel_lib to latest bazel_lib

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,7 @@ bazel_dep(name = "rules_go", version = "0.52.0")
 bazel_dep(name = "rules_java", version = "8.5.1")
 bazel_dep(name = "rules_jvm_external", version = "6.7")
 bazel_dep(name = "rules_proto", version = "7.0.2")
-bazel_dep(name = "aspect_bazel_lib", version = "1.42.3")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
 
 bazel_dep(name = "bazel_skylib_gazelle_plugin", version = "1.8.1", dev_dependency = True)
 bazel_dep(name = "rules_python", version = "1.5.4", dev_dependency = True)

--- a/java/gazelle/private/servermanager/BUILD.bazel
+++ b/java/gazelle/private/servermanager/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@rules_go//go:def.bzl", "go_library")
 
 go_library(


### PR DESCRIPTION
The old bazel lib is not compatible with new starlark-based targets, which can be enabled with `--incompatible_disable_native_repo_rules`.

This change is required to publish the rules to the BCR along with all the presubmit configurations.