### PR TITLE
Fix pmd_test to use short_path instead of path for sources

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -21,7 +21,7 @@ def _pmd_test_impl(ctx):
     file_list = ctx.actions.declare_file("%s-pmd-srcs" % ctx.label.name)
     ctx.actions.write(
         file_list,
-        ",".join([src.path for src in ctx.files.srcs]),
+        ",".join([src.short_path for src in ctx.files.srcs]),
     )
     cmd.extend(["--file-list", file_list.short_path])
     inputs.extend(ctx.files.srcs)


### PR DESCRIPTION
From https://bazel.build/rules/lib/builtins/File#path:

> Use the `short_path` for the path under which the file is mapped if it's in the runfiles of a binary. 

Fixes an issue with `pmd_test` not finding sources produced by other targets.