### PR TITLE
Fix rule set path handling in pmd.bzl

### DIFF
--- a/java/private/pmd.bzl
+++ b/java/private/pmd.bzl
@@ -27,7 +27,7 @@ def _pmd_test_impl(ctx):
     inputs.extend(ctx.files.srcs)
     inputs.append(file_list)
 
-    cmd.extend(["-R", ",".join([rs.path for rs in pmd_info.rulesets.to_list()])])
+    cmd.extend(["-R", ",".join([rs.short_path for rs in pmd_info.rulesets.to_list()])])
     inputs.extend(pmd_info.rulesets.to_list())
 
     cmd.extend(["-f", pmd_info.format])


### PR DESCRIPTION
This PR fixes an issue where the rulesets will not be found with Bazel 8 (actually tested only with 8.5).

We need the `short_path` here which is intended to be used for locating runfiles during execution of a binary.

Without this change, you will get:

```
[main] ERROR net.sourceforge.pmd.cli - Cannot load ruleset external/contrib_rules_jvm+/java/pmd-ruleset.xml: Cannot resolve rule/ruleset reference 'external/contrib_rules_jvm+/java/pmd-ruleset.xml'.  Make sure the resource is a valid file or URL and is on the CLASSPATH. Use --debug (or a fine log level) to see the current classpath.
```