### PR TITLE
Fix visibility of //java/gazelle:embedded_server

### DIFF
--- a/java/gazelle/BUILD.bazel
+++ b/java/gazelle/BUILD.bazel
@@ -125,4 +125,5 @@ config_setting(
     flag_values = {
         "//java/gazelle:embed_server": "True",
     },
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This allows rules to work even with
`--incompatible_config_setting_private_default_visibility`

Bazel issue: https://github.com/bazelbuild/bazel/issues/12933

Issue: https://github.com/bazel-contrib/rules_jvm/issues/402