### PR TITLE
[gazelle] Index classes that are generated by proto files

### DIFF
--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -422,7 +422,9 @@ func (jr *Resolver) buildPackageClassIndex(c *config.Config, pkg types.PackageNa
 	}
 
 	for _, m := range matches {
-		info, ok := jr.lang.classExportCache[m.Label.String()]
+		// Try lookup without repo prefix since that's how we store entries
+		cacheLabel := label.New("", m.Label.Pkg, m.Label.Name)
+		info, ok := jr.lang.classExportCache[cacheLabel.String()]
 		if !ok {
 			continue
 		}


### PR DESCRIPTION
It's common to have multiple `proto` files grouped together that generate classes for different packages. It's also common to have `proto` files scattered through the tree that generate classes that are in the same package. Because of this, we should add the classes generated by protobuf to the class index.