### PR TITLE
[gazelle] Allow other plugins to also contribute to class location

### DIFF
--- a/java/gazelle/javaconfig/BUILD.bazel
+++ b/java/gazelle/javaconfig/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//java/gazelle/private/sorted_set",
         "//java/gazelle/private/types",
+        "@bazel_gazelle//config",
         "@com_github_bazelbuild_buildtools//build",
     ],
 )

--- a/java/gazelle/javaconfig/config.go
+++ b/java/gazelle/javaconfig/config.go
@@ -8,56 +8,61 @@ import (
 
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/sorted_set"
 	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/types"
+	"github.com/bazelbuild/bazel-gazelle/config"
 	bzl "github.com/bazelbuild/buildtools/build"
 )
 
+// SharedClassInfo represents class export information for a single rule.
+// Used in the shared class cache for cross-plugin class-level resolution.
+type SharedClassInfo struct {
+	// Classes are the fully-qualified Java class names this rule provides.
+	Classes []string
+
+	// TestOnly indicates whether these classes are only available for test rules.
+	TestOnly bool
+}
+
+// SharedClassCache is a shared cache of class information keyed by rule label.
+// This is stored in config.Exts and shared across all Gazelle plugins, allowing
+// external plugins to contribute class information for split package resolution.
+// The key is the rule label string (e.g., "//pkg:rule_name").
+type SharedClassCache map[string]SharedClassInfo
+
+// JavaSharedClassCacheKey is the config.Exts key for the shared class cache.
+// External plugins should use GetOrCreateSharedClassCache to access it.
+const JavaSharedClassCacheKey = "java_shared_class_cache"
+
+// GetOrCreateSharedClassCache returns the shared class cache from config.Exts,
+// creating it if it doesn't exist. The cache is shared across all plugins and
+// persists across directory boundaries because it's a pointer to a map.
+//
+// External plugins should call this in their Configure method (at the root level)
+// and store the returned pointer for use in GenerateRules.
+//
+// Example usage in an external plugin:
+//
+//	func (l *myLang) Configure(c *config.Config, rel string, f *rule.File) {
+//	    cache := javaconfig.GetOrCreateSharedClassCache(c)
+//	    // Store cache pointer for later use
+//	}
+//
+//	func (l *myLang) GenerateRules(args language.GenerateArgs) language.GenerateResult {
+//	    cache := javaconfig.GetOrCreateSharedClassCache(args.Config)
+//	    cache["//pkg:my_rule"] = javaconfig.SharedClassInfo{
+//	        Classes:  []string{"com.example.MyClass"},
+//	        TestOnly: false,
+//	    }
+//	}
+func GetOrCreateSharedClassCache(c *config.Config) SharedClassCache {
+	if cache, ok := c.Exts[JavaSharedClassCacheKey].(SharedClassCache); ok {
+		return cache
+	}
+	cache := make(SharedClassCache)
+	c.Exts[JavaSharedClassCacheKey] = cache
+	return cache
+}
+
 const (
-	// JavaExtensionLibraryKindsKey is a well-known config.Exts key that other Gazelle plugins
-	// can use to register additional rule kinds as JVM libraries. The value should be a
-	// map[string]bool where keys are rule kinds (e.g., "java_wire_library").
-	//
-	// Example usage in another plugin's Configure method:
-	//
-	//     kinds, _ := c.Exts[javaconfig.JavaExtensionLibraryKindsKey].(map[string]bool)
-	//     if kinds == nil {
-	//         kinds = make(map[string]bool)
-	//     }
-	//     kinds["my_custom_library"] = true
-	//     c.Exts[javaconfig.JavaExtensionLibraryKindsKey] = kinds
-	//
-	JavaExtensionLibraryKindsKey = "java_extension_library_kinds"
-
-	// JavaGazelleProvidedPackagesAttr is a well-known private attribute key that other
-	// Gazelle plugins can set on their rules to declare Java packages they provide.
-	// The value should be []string where each string is a Java package name
-	// (e.g., "com.example.proto").
-	//
-	// When set, the Java plugin will register these packages in Gazelle's RuleIndex,
-	// enabling package-level dependency resolution for the external rule.
-	//
-	// Example usage in another plugin's GenerateRules:
-	//
-	//     r.SetPrivateAttr(javaconfig.JavaGazelleProvidedPackagesAttr, []string{"com.example"})
-	//
-	JavaGazelleProvidedPackagesAttr = "_java_gazelle_provided_packages"
-
-	// JavaGazelleProvidedClassesAttr is a well-known private attribute key that other
-	// Gazelle plugins can set on their rules to declare fully-qualified Java class names
-	// they provide. The value should be []string where each string is a fully-qualified
-	// class name (e.g., "com.example.Person").
-	//
-	// When set, the Java plugin will add these classes to its class export cache,
-	// enabling class-level dependency resolution for split packages.
-	//
-	// Example usage in another plugin's GenerateRules:
-	//
-	//     r.SetPrivateAttr(javaconfig.JavaGazelleProvidedClassesAttr, []string{
-	//         "com.example.Person",
-	//         "com.example.Address",
-	//     })
-	//
-	JavaGazelleProvidedClassesAttr = "_java_gazelle_provided_classes"
-
 	// JavaExcludeArtifact tells the resolver to disregard a given maven artifact.
 	// Can be repeated.
 	JavaExcludeArtifact = "java_exclude_artifact"

--- a/java/gazelle/resolve_test.go
+++ b/java/gazelle/resolve_test.go
@@ -544,251 +544,148 @@ java_library(
 	}
 }
 
-func TestIsJvmLibraryWithExtensionKinds(t *testing.T) {
-	c := &config.Config{
-		Exts: make(map[string]interface{}),
-	}
-
-	// Built-in kinds should be recognized
-	if !isJvmLibrary(c, "java_library") {
-		t.Error("java_library should be recognized as JVM library")
-	}
-	if !isJvmLibrary(c, "kt_jvm_library") {
-		t.Error("kt_jvm_library should be recognized as JVM library")
-	}
-	if !isJvmLibrary(c, "java_proto_library") {
-		t.Error("java_proto_library should be recognized as JVM library")
-	}
-	if !isJvmLibrary(c, "java_grpc_library") {
-		t.Error("java_grpc_library should be recognized as JVM library")
-	}
-
-	// Proto library helper functions should work correctly
-	if !isJavaProtoLibrary(c, "java_proto_library") {
-		t.Error("java_proto_library should be recognized as Java proto library")
-	}
-	if !isJavaProtoLibrary(c, "java_grpc_library") {
-		t.Error("java_grpc_library should be recognized as Java proto library")
-	}
-	if isJavaProtoLibrary(c, "java_library") {
-		t.Error("java_library should not be recognized as Java proto library")
-	}
-
-	// Unknown kinds should not be recognized by default
-	if isJvmLibrary(c, "custom_jvm_library") {
-		t.Error("custom_jvm_library should not be recognized without registration")
-	}
-
-	// Register a custom kind via the extension mechanism
-	extKinds := make(map[string]bool)
-	extKinds["custom_jvm_library"] = true
-	extKinds["java_wire_library"] = true
-	c.Exts[javaconfig.JavaExtensionLibraryKindsKey] = extKinds
-
-	// Now custom kinds should be recognized
-	if !isJvmLibrary(c, "custom_jvm_library") {
-		t.Error("custom_jvm_library should be recognized after registration")
-	}
-	if !isJvmLibrary(c, "java_wire_library") {
-		t.Error("java_wire_library should be recognized after registration")
-	}
-
-	// Unregistered kinds should still not be recognized
-	if isJvmLibrary(c, "some_other_library") {
-		t.Error("some_other_library should not be recognized")
-	}
-
-	// Built-in kinds should still work
-	if !isJvmLibrary(c, "java_library") {
-		t.Error("java_library should still be recognized")
-	}
+// fakeExternalPluginResolver simulates an external plugin (like rules_wire)
+// that returns Java ImportSpecs for its custom rule kinds.
+type fakeExternalPluginResolver struct {
+	// javaPackages maps rule names to the Java packages they provide
+	javaPackages map[string][]types.ResolvableJavaPackage
 }
 
-func TestExternalPluginContributedPackages(t *testing.T) {
-	c, langs, _ := testConfig(t)
-
-	var javaLangInstance *javaLang
-	for _, lang := range langs {
-		if jl, ok := lang.(*javaLang); ok {
-			javaLangInstance = jl
-			break
-		}
-	}
-	if javaLangInstance == nil {
-		t.Fatal("javaLang not found")
-	}
-
-	// Register java_wire_library as a JVM library kind
-	extKinds := make(map[string]bool)
-	extKinds["java_wire_library"] = true
-	c.Exts[javaconfig.JavaExtensionLibraryKindsKey] = extKinds
-
-	pkg := "protos"
-	wireLibContent := `java_wire_library(
-    name = "person_wire",
-    proto = ":person_proto",
-)
-`
-	wireFile, err := rule.LoadData("BUILD.bazel", pkg, []byte(wireLibContent))
-	if err != nil {
-		t.Fatalf("failed to load BUILD file: %v", err)
-	}
-
-	wireRule := wireFile.Rules[0]
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedPackagesAttr, []string{"com.example.proto"})
-
-	resolver := NewResolver(javaLangInstance)
-	imports := resolver.Imports(c, wireRule, wireFile)
-
-	// Should have registered the package
-	if len(imports) != 1 {
-		t.Fatalf("expected 1 import spec, got %d", len(imports))
-	}
-	if imports[0].Lang != "java" {
-		t.Errorf("expected lang 'java', got %s", imports[0].Lang)
-	}
-	if imports[0].Imp != "com.example.proto" {
-		t.Errorf("expected import 'com.example.proto', got %s", imports[0].Imp)
-	}
+func (r *fakeExternalPluginResolver) Name() string {
+	return "java" // Returns "java" so ImportSpecs are indexed under the Java language
 }
 
-func TestExternalPluginContributedClasses(t *testing.T) {
-	c, langs, _ := testConfig(t)
-
-	var javaLangInstance *javaLang
-	for _, lang := range langs {
-		if jl, ok := lang.(*javaLang); ok {
-			javaLangInstance = jl
-			break
-		}
-	}
-	if javaLangInstance == nil {
-		t.Fatal("javaLang not found")
-	}
-
-	pkg := "protos"
-	wireLibContent := `java_wire_library(
-    name = "person_wire",
-    proto = ":person_proto",
-)
-`
-	wireFile, err := rule.LoadData("BUILD.bazel", pkg, []byte(wireLibContent))
-	if err != nil {
-		t.Fatalf("failed to load BUILD file: %v", err)
-	}
-
-	wireRule := wireFile.Rules[0]
-	// Only provide classes, not packages - should infer packages
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedClassesAttr, []string{
-		"com.example.proto.Person",
-		"com.example.proto.Address",
-	})
-
-	resolver := NewResolver(javaLangInstance)
-	imports := resolver.Imports(c, wireRule, wireFile)
-
-	// Should have inferred and registered the package from class names
-	if len(imports) != 1 {
-		t.Fatalf("expected 1 import spec (inferred package), got %d", len(imports))
-	}
-	if imports[0].Imp != "com.example.proto" {
-		t.Errorf("expected inferred package 'com.example.proto', got %s", imports[0].Imp)
-	}
-
-	// Should have populated classExportCache
-	lbl := label.New("", pkg, "person_wire")
-	info, ok := javaLangInstance.classExportCache[lbl.String()]
+func (r *fakeExternalPluginResolver) Imports(c *config.Config, rule *rule.Rule, f *rule.File) []resolve.ImportSpec {
+	pkgs, ok := r.javaPackages[rule.Name()]
 	if !ok {
-		t.Fatal("classExportCache should contain the wire rule")
+		return nil
 	}
-	if len(info.classes) != 2 {
-		t.Errorf("expected 2 classes in cache, got %d", len(info.classes))
+	var specs []resolve.ImportSpec
+	for _, pkg := range pkgs {
+		specs = append(specs, resolve.ImportSpec{Lang: "java", Imp: pkg.String()})
 	}
-
-	// Verify the classes were parsed correctly
-	classNames := make(map[string]bool)
-	for _, cls := range info.classes {
-		classNames[cls.BareOuterClassName()] = true
-	}
-	if !classNames["Person"] {
-		t.Error("Person class should be in cache")
-	}
-	if !classNames["Address"] {
-		t.Error("Address class should be in cache")
-	}
+	return specs
 }
 
-func TestExternalPluginClassesWithExplicitPackages(t *testing.T) {
-	c, langs, _ := testConfig(t)
-
-	var javaLangInstance *javaLang
-	for _, lang := range langs {
-		if jl, ok := lang.(*javaLang); ok {
-			javaLangInstance = jl
-			break
-		}
-	}
-	if javaLangInstance == nil {
-		t.Fatal("javaLang not found")
-	}
-
-	pkg := "protos"
-	wireLibContent := `java_wire_library(
-    name = "person_wire",
-    proto = ":person_proto",
-)
-`
-	wireFile, err := rule.LoadData("BUILD.bazel", pkg, []byte(wireLibContent))
-	if err != nil {
-		t.Fatalf("failed to load BUILD file: %v", err)
-	}
-
-	wireRule := wireFile.Rules[0]
-	// Provide both packages and classes
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedPackagesAttr, []string{"com.example.proto"})
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedClassesAttr, []string{
-		"com.example.proto.Person",
-		"com.example.proto.Address",
-	})
-
-	resolver := NewResolver(javaLangInstance)
-	imports := resolver.Imports(c, wireRule, wireFile)
-
-	// Should have exactly 1 import (explicit package, not inferred)
-	if len(imports) != 1 {
-		t.Fatalf("expected 1 import spec, got %d", len(imports))
-	}
-
-	// Should still have populated classExportCache
-	lbl := label.New("", pkg, "person_wire")
-	info, ok := javaLangInstance.classExportCache[lbl.String()]
-	if !ok {
-		t.Fatal("classExportCache should contain the wire rule")
-	}
-	if len(info.classes) != 2 {
-		t.Errorf("expected 2 classes in cache, got %d", len(info.classes))
-	}
+func (r *fakeExternalPluginResolver) Embeds(rule *rule.Rule, from label.Label) []label.Label {
+	return nil
 }
 
-func TestExternalPluginClassesInSplitPackageResolution(t *testing.T) {
-	c, langs, _ := testConfig(t)
+func (r *fakeExternalPluginResolver) Resolve(c *config.Config, ix *resolve.RuleIndex, rc *repo.RemoteCache, rule *rule.Rule, imports interface{}, from label.Label) {
+}
 
-	// Register java_wire_library as a JVM library kind
-	extKinds := make(map[string]bool)
-	extKinds["java_wire_library"] = true
-	c.Exts[javaconfig.JavaExtensionLibraryKindsKey] = extKinds
+func TestSharedClassCacheForExternalPlugins(t *testing.T) {
+	c, langs, _ := testConfig(t)
 
 	mrslv, exts := InitTestResolversAndExtensions(langs)
 
-	// Also register java_wire_library in the resolver map so the Java resolver handles it
-	// (In production, this happens because the kind is registered via JavaExtensionLibraryKindsKey)
+	var javaLangInstance *javaLang
 	for _, lang := range langs {
-		if _, ok := lang.(*javaLang); ok {
-			mrslv["java_wire_library"] = lang
+		if jl, ok := lang.(*javaLang); ok {
+			javaLangInstance = jl
 			break
 		}
 	}
+	if javaLangInstance == nil {
+		t.Fatal("javaLang not found")
+	}
 
+	pkg := "splitpkg"
+	javaPackage := types.NewPackageName("com.example.split")
+
+	// Create a fake external plugin resolver for java_wire_library.
+	// In production, this would be the Wire plugin returning Java ImportSpecs.
+	fakeWireResolver := &fakeExternalPluginResolver{
+		javaPackages: map[string][]types.ResolvableJavaPackage{
+			"wire_proto": {*types.NewResolvableJavaPackage(javaPackage, false, false)},
+		},
+	}
+	mrslv["java_wire_library"] = fakeWireResolver
+
+	ix := resolve.NewRuleIndex(mrslv.Resolver, exts...)
+
+	// Create a java_library that provides the package (represents hand-written code)
+	javaLibContent := `
+java_library(
+    name = "java_part",
+    srcs = ["JavaPart.java"],
+)
+`
+	buildPath := filepath.Join(filepath.FromSlash(pkg), "BUILD.bazel")
+	javaFile, err := rule.LoadData(buildPath, pkg, []byte(javaLibContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	javaRule := javaFile.Rules[0]
+
+	// Set up the java_library with its package
+	javaRule.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, false, false),
+	})
+
+	// Set up classExportCache for java_library (simulating generation)
+	javaLabel := label.New("", pkg, "java_part")
+	javaLangInstance.classExportCache[javaLabel.String()] = classExportInfo{
+		classes:  []types.ClassName{types.NewClassName(javaPackage, "JavaPart")},
+		testonly: false,
+	}
+
+	// Create a java_wire_library rule (external plugin's rule kind)
+	wireLibContent := `
+java_wire_library(
+    name = "wire_proto",
+    proto = ":person_proto",
+)
+`
+	wireFile, err := rule.LoadData(buildPath, pkg, []byte(wireLibContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wireRule := wireFile.Rules[0]
+
+	// External plugin contributes class info via shared cache (not classExportCache).
+	// This is the key difference: internal rules use classExportCache,
+	// external plugins use SharedClassCache.
+	sharedCache := javaconfig.GetOrCreateSharedClassCache(c)
+	wireLabel := label.New("", pkg, "wire_proto")
+	sharedCache[wireLabel.String()] = javaconfig.SharedClassInfo{
+		Classes:  []string{"com.example.split.WireMessage"},
+		TestOnly: false,
+	}
+
+	// Add both rules to the index
+	ix.AddRule(c, javaRule, javaFile)
+	ix.AddRule(c, wireRule, wireFile)
+	ix.Finish()
+
+	resolver := NewResolver(javaLangInstance)
+
+	// Build the class index for this split package
+	pci := resolver.buildPackageClassIndex(c, javaPackage, ix)
+
+	// The java_library class should be indexed from classExportCache
+	if _, ok := pci.prod["JavaPart"]; !ok {
+		t.Error("JavaPart should be indexed from java_library's classExportCache")
+	}
+
+	// The java_wire_library class should be indexed from SharedClassCache
+	if _, ok := pci.prod["WireMessage"]; !ok {
+		t.Error("WireMessage should be indexed from SharedClassCache")
+	}
+
+	// Verify both classes map to their respective labels
+	if len(pci.prod["JavaPart"]) != 1 || pci.prod["JavaPart"][0].Name != "java_part" {
+		t.Errorf("JavaPart should map to java_part, got %v", pci.prod["JavaPart"])
+	}
+	if len(pci.prod["WireMessage"]) != 1 || pci.prod["WireMessage"][0].Name != "wire_proto" {
+		t.Errorf("WireMessage should map to wire_proto, got %v", pci.prod["WireMessage"])
+	}
+}
+
+func TestClassLevelResolutionInSplitPackage(t *testing.T) {
+	c, langs, _ := testConfig(t)
+
+	mrslv, exts := InitTestResolversAndExtensions(langs)
 	ix := resolve.NewRuleIndex(mrslv.Resolver, exts...)
 
 	var javaLangInstance *javaLang
@@ -805,68 +702,61 @@ func TestExternalPluginClassesInSplitPackageResolution(t *testing.T) {
 	pkg := "splitpkg"
 	javaPackage := types.NewPackageName("com.example.split")
 
-	// Create two rules in the same package - simulating a split package scenario
-	// One is a regular java_library, one is an external plugin rule (java_wire_library)
-
-	javaLibContent := `
+	// Create two java_library rules in the same package - simulating a split package scenario
+	javaLib1Content := `
 java_library(
-    name = "java_part",
-    srcs = ["JavaPart.java"],
-    _packages = ["com.example.split"],
+    name = "java_part1",
+    srcs = ["JavaPart1.java"],
 )
 `
-	wireLibContent := `
-java_wire_library(
-    name = "wire_part",
-    proto = ":messages_proto",
+	javaLib2Content := `
+java_library(
+    name = "java_part2",
+    srcs = ["JavaPart2.java"],
 )
 `
 
 	buildPath := filepath.Join(filepath.FromSlash(pkg), "BUILD.bazel")
 
-	javaFile, err := rule.LoadData(buildPath, pkg, []byte(javaLibContent))
+	javaFile1, err := rule.LoadData(buildPath, pkg, []byte(javaLib1Content))
 	if err != nil {
 		t.Fatal(err)
 	}
-	wireFile, err := rule.LoadData(buildPath, pkg, []byte(wireLibContent))
+	javaFile2, err := rule.LoadData(buildPath, pkg, []byte(javaLib2Content))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	javaRule := javaFile.Rules[0]
-	wireRule := wireFile.Rules[0]
+	javaRule1 := javaFile1.Rules[0]
+	javaRule2 := javaFile2.Rules[0]
 
-	// Set up the java_library with its package (uses internal packagesKey)
-	setPackagesPrivateAttr(javaRule)
-
-	// Set up the wire rule with contributed packages and classes (simulating Wire plugin)
-	// This tests the new extension mechanism where external plugins set these attrs
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedPackagesAttr, []string{"com.example.split"})
-	wireRule.SetPrivateAttr(javaconfig.JavaGazelleProvidedClassesAttr, []string{
-		"com.example.split.WireMessage",
+	// Set up both rules with the same package (split package scenario)
+	javaRule1.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, false, false),
+	})
+	javaRule2.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, false, false),
 	})
 
-	// Manually set up classExportCache for both rules (simulating what happens
-	// when Imports() is called during the real gazelle flow)
-	javaLabel := label.New("", pkg, "java_part")
-	javaLangInstance.classExportCache[javaLabel.String()] = classExportInfo{
-		classes:  []types.ClassName{types.NewClassName(javaPackage, "JavaPart")},
+	// Set up classExportCache for both rules (simulating what happens during generation)
+	javaLabel1 := label.New("", pkg, "java_part1")
+	javaLangInstance.classExportCache[javaLabel1.String()] = classExportInfo{
+		classes:  []types.ClassName{types.NewClassName(javaPackage, "ClassA")},
 		testonly: false,
 	}
 
-	wireLabel := label.New("", pkg, "wire_part")
-	javaLangInstance.classExportCache[wireLabel.String()] = classExportInfo{
-		classes:  []types.ClassName{types.NewClassName(javaPackage, "WireMessage")},
+	javaLabel2 := label.New("", pkg, "java_part2")
+	javaLangInstance.classExportCache[javaLabel2.String()] = classExportInfo{
+		classes:  []types.ClassName{types.NewClassName(javaPackage, "ClassB")},
 		testonly: false,
 	}
 
-	// Add rules to the index - the resolver will call Imports() which reads the private attrs
-	ix.AddRule(c, javaRule, javaFile)
-	ix.AddRule(c, wireRule, wireFile)
-
+	// Add rules to the index
+	ix.AddRule(c, javaRule1, javaFile1)
+	ix.AddRule(c, javaRule2, javaFile2)
 	ix.Finish()
 
-	// Verify both rules are indexed for the package
+	// Verify both rules are indexed for the package (split package)
 	importSpec := resolve.ImportSpec{Lang: "java", Imp: javaPackage.Name}
 	matches := ix.FindRulesByImportWithConfig(c, importSpec, "java")
 	if len(matches) != 2 {
@@ -879,15 +769,115 @@ java_wire_library(
 	pci := resolver.buildPackageClassIndex(c, javaPackage, ix)
 
 	// Both classes should be indexed
-	if _, ok := pci.prod["JavaPart"]; !ok {
-		t.Error("JavaPart class should be indexed from java_library")
+	if _, ok := pci.prod["ClassA"]; !ok {
+		t.Error("ClassA should be indexed from java_part1")
 	}
-	if _, ok := pci.prod["WireMessage"]; !ok {
-		t.Error("WireMessage class should be indexed from java_wire_library")
+	if _, ok := pci.prod["ClassB"]; !ok {
+		t.Error("ClassB should be indexed from java_part2")
 	}
 
 	// Verify correct labels
-	if len(pci.prod["WireMessage"]) != 1 || pci.prod["WireMessage"][0] != wireLabel {
-		t.Errorf("WireMessage should be provided by wire_part, got %v", pci.prod["WireMessage"])
+	if len(pci.prod["ClassA"]) != 1 || pci.prod["ClassA"][0] != javaLabel1 {
+		t.Errorf("ClassA should be provided by java_part1, got %v", pci.prod["ClassA"])
+	}
+	if len(pci.prod["ClassB"]) != 1 || pci.prod["ClassB"][0] != javaLabel2 {
+		t.Errorf("ClassB should be provided by java_part2, got %v", pci.prod["ClassB"])
+	}
+}
+
+func TestSharedClassCacheTestOnlyHandling(t *testing.T) {
+	c, langs, _ := testConfig(t)
+
+	mrslv, exts := InitTestResolversAndExtensions(langs)
+	ix := resolve.NewRuleIndex(mrslv.Resolver, exts...)
+
+	var javaLangInstance *javaLang
+	for _, lang := range langs {
+		if jl, ok := lang.(*javaLang); ok {
+			javaLangInstance = jl
+			break
+		}
+	}
+	if javaLangInstance == nil {
+		t.Fatal("javaLang not found")
+	}
+
+	pkg := "testpkg"
+	javaPackage := types.NewPackageName("com.example.test")
+
+	// Create a testonly java_library (simulates test utilities from external plugin)
+	testLibContent := `
+java_library(
+    name = "test_helper",
+    srcs = ["TestHelper.java"],
+    testonly = True,
+)
+`
+	buildPath := filepath.Join(filepath.FromSlash(pkg), "BUILD.bazel")
+	testFile, err := rule.LoadData(buildPath, pkg, []byte(testLibContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	testRule := testFile.Rules[0]
+
+	// Set up the testonly rule with its package (using testonly=true ImportSpec)
+	testRule.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, true, false), // testonly=true
+	})
+
+	// External plugin contributes testonly class info via shared cache
+	sharedCache := javaconfig.GetOrCreateSharedClassCache(c)
+	testLabel := label.New("", pkg, "test_helper")
+	sharedCache[testLabel.String()] = javaconfig.SharedClassInfo{
+		Classes:  []string{"com.example.test.TestHelper"},
+		TestOnly: true,
+	}
+
+	// Create a prod java_library
+	prodLibContent := `
+java_library(
+    name = "prod_helper",
+    srcs = ["ProdHelper.java"],
+)
+`
+	prodFile, err := rule.LoadData(buildPath, pkg, []byte(prodLibContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	prodRule := prodFile.Rules[0]
+
+	// Set up the prod rule with its package
+	prodRule.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, false, false),
+	})
+
+	// External plugin contributes prod class info via shared cache
+	prodLabel := label.New("", pkg, "prod_helper")
+	sharedCache[prodLabel.String()] = javaconfig.SharedClassInfo{
+		Classes:  []string{"com.example.test.ProdHelper"},
+		TestOnly: false,
+	}
+
+	// Add rules to the index
+	ix.AddRule(c, testRule, testFile)
+	ix.AddRule(c, prodRule, prodFile)
+	ix.Finish()
+
+	resolver := NewResolver(javaLangInstance)
+
+	// Build the class index for this package
+	pci := resolver.buildPackageClassIndex(c, javaPackage, ix)
+
+	// ProdHelper should be in prod index
+	if _, ok := pci.prod["ProdHelper"]; !ok {
+		t.Error("ProdHelper should be in prod index")
+	}
+
+	// TestHelper should be in test index (not prod)
+	if _, ok := pci.test["TestHelper"]; !ok {
+		t.Error("TestHelper should be in test index")
+	}
+	if _, ok := pci.prod["TestHelper"]; ok {
+		t.Error("TestHelper should NOT be in prod index")
 	}
 }


### PR DESCRIPTION
When multiple rules create a "split package", Gazelle needs class-level resolution to determine which rule provides which class. Previously, only the built-in Java plugin could participate in this resolution via the internal `classExportCache`. Other gazelle plugins which generate java classes (such as a possible one for [Wire](https://square.github.io/wire/)) could not.

This PR introduces a `SharedClassCache` in `config.Exts` that external plugins can populate with their class information:

```go
// In external plugin's GenerateRules:
cache := javaconfig.GetOrCreateSharedClassCache(args.Config)
cache["//pkg:my_wire_rule"] = javaconfig.SharedClassInfo{
    Classes:  []string{"com.example.MyGeneratedClass"},
    TestOnly: false,
}
```

The Java plugin's `buildPackageClassIndex` now consults both:

1. Internal classExportCache (for java_library rules)
2. SharedClassCache (for external plugin rules)