### PR TITLE
Show error logs when test ends due to TIMEOUT

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/OutputCapture.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/OutputCapture.java
@@ -1,0 +1,166 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Captures stdout and stderr independently of JUnit Platform's capture mechanism.
+ *
+ * <p>This class wraps System.out and System.err with tee streams that write to both the original
+ * stream and an internal buffer. This ensures output is captured even when tests are interrupted
+ * (e.g., by SIGTERM due to timeout) before JUnit Platform can publish the captured output.
+ */
+public class OutputCapture {
+
+  private static final String MAX_BYTES_PROPERTY = "junit5.outputCapture.maxBytes";
+  private static final int DEFAULT_MAX_BYTES = 10 * 1024 * 1024; // 10MB
+
+  private final PrintStream originalOut;
+  private final PrintStream originalErr;
+  private final BoundedByteArrayOutputStream stdoutBuffer;
+  private final BoundedByteArrayOutputStream stderrBuffer;
+  private volatile boolean started = false;
+
+  public OutputCapture() {
+    this.originalOut = System.out;
+    this.originalErr = System.err;
+
+    int maxBytes = getMaxCaptureSize();
+    this.stdoutBuffer = new BoundedByteArrayOutputStream(maxBytes);
+    this.stderrBuffer = new BoundedByteArrayOutputStream(maxBytes);
+  }
+
+  private static int getMaxCaptureSize() {
+    return Integer.getInteger(MAX_BYTES_PROPERTY, DEFAULT_MAX_BYTES);
+  }
+
+  /** Start capturing stdout and stderr. */
+  public synchronized void start() {
+    if (started) {
+      return;
+    }
+
+    System.setOut(new PrintStream(new TeeOutputStream(originalOut, stdoutBuffer), true));
+    System.setErr(new PrintStream(new TeeOutputStream(originalErr, stderrBuffer), true));
+    started = true;
+  }
+
+  /** Stop capturing and restore original streams. */
+  public synchronized void stop() {
+    if (!started) {
+      return;
+    }
+
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+    started = false;
+  }
+
+  /** Get captured stdout content. */
+  public String getStdout() {
+    return stdoutBuffer.toString(StandardCharsets.UTF_8);
+  }
+
+  /** Get captured stderr content. */
+  public String getStderr() {
+    return stderrBuffer.toString(StandardCharsets.UTF_8);
+  }
+
+  /** Check if any stdout was captured. */
+  public boolean hasStdout() {
+    return stdoutBuffer.size() > 0;
+  }
+
+  /** Check if any stderr was captured. */
+  public boolean hasStderr() {
+    return stderrBuffer.size() > 0;
+  }
+
+  /** OutputStream that writes to two underlying streams. */
+  private static class TeeOutputStream extends OutputStream {
+    private final OutputStream primary;
+    private final OutputStream secondary;
+
+    TeeOutputStream(OutputStream primary, OutputStream secondary) {
+      this.primary = primary;
+      this.secondary = secondary;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      primary.write(b);
+      secondary.write(b);
+    }
+
+    @Override
+    public void write(byte[] b) throws IOException {
+      primary.write(b);
+      secondary.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      primary.write(b, off, len);
+      secondary.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      primary.flush();
+      secondary.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      primary.flush();
+      secondary.flush();
+    }
+  }
+
+  /** ByteArrayOutputStream with a maximum size limit to prevent OOM. */
+  private static class BoundedByteArrayOutputStream extends ByteArrayOutputStream {
+    private final int maxSize;
+    private boolean overflow = false;
+
+    BoundedByteArrayOutputStream(int maxSize) {
+      this.maxSize = maxSize;
+    }
+
+    @Override
+    public synchronized void write(int b) {
+      if (size() >= maxSize) {
+        overflow = true;
+        return;
+      }
+      super.write(b);
+    }
+
+    @Override
+    public synchronized void write(byte[] b, int off, int len) {
+      if (size() >= maxSize) {
+        overflow = true;
+        return;
+      }
+
+      int available = maxSize - size();
+      int toWrite = Math.min(len, available);
+      super.write(b, off, toWrite);
+
+      if (toWrite < len) {
+        overflow = true;
+      }
+    }
+
+    @Override
+    public synchronized String toString(java.nio.charset.Charset charset) {
+      String result = new String(toByteArray(), charset);
+      if (overflow) {
+        result += "\n[OUTPUT TRUNCATED - exceeded " + (maxSize / 1024 / 1024) + "MB limit]";
+      }
+      return result;
+    }
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestData.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestData.java
@@ -22,6 +22,8 @@ class TestData {
   private String reason;
   private TestExecutionResult result;
   private boolean dynamic;
+  private String fallbackStdOut;
+  private String fallbackStdErr;
 
   TestData(TestIdentifier id) {
     this.id = id;
@@ -124,7 +126,7 @@ class TestData {
         .map(EntryDetails::getStdOut)
         .filter(Objects::nonNull)
         .findFirst()
-        .orElse(null);
+        .orElse(fallbackStdOut);
   }
 
   public String getStdErr() {
@@ -132,7 +134,7 @@ class TestData {
         .map(EntryDetails::getStdErr)
         .filter(Objects::nonNull)
         .findFirst()
-        .orElse(null);
+        .orElse(fallbackStdErr);
   }
 
   public TestData setDynamic(boolean isDynamic) {
@@ -142,6 +144,18 @@ class TestData {
 
   public boolean isDynamic() {
     return dynamic;
+  }
+
+  /** Set fallback stdout for tests interrupted before JUnit Platform capture is published. */
+  public TestData setFallbackStdOut(String stdout) {
+    this.fallbackStdOut = stdout;
+    return this;
+  }
+
+  /** Set fallback stderr for tests interrupted before JUnit Platform capture is published. */
+  public TestData setFallbackStdErr(String stderr) {
+    this.fallbackStdErr = stderr;
+    return this;
   }
 
   public Instant getStarted() {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -21,12 +21,16 @@ VINTAGE_NESTED_TEST = [
     "NestedClassesVintageTest.java",
 ]
 
+TIMEOUT_OUTPUT_CAPTURE_TEST = [
+    "TimeoutOutputCaptureTest.java",
+]
+
 java_test_suite(
     name = "small-tests",
     size = "small",
     srcs = glob(
         ["*.java"],
-        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST + VINTAGE_NESTED_TEST,
+        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST + VINTAGE_NESTED_TEST + TIMEOUT_OUTPUT_CAPTURE_TEST,
     ),
     exclude_engines = ["junit-vintage"],
     include_engines = ["junit-jupiter"],
@@ -106,5 +110,19 @@ java_junit5_test(
         "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
         artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
         artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+# Integration test for timeout stdout capture. This test intentionally times out
+# to verify that stdout is captured even when tests are interrupted by SIGTERM.
+# Run with: bazel test //java/test/.../junit5:timeout-output-capture-test --test_timeout=3
+java_junit5_test(
+    name = "timeout-output-capture-test",
+    size = "small",
+    srcs = TIMEOUT_OUTPUT_CAPTURE_TEST,
+    tags = ["manual"],  # Don't run in normal test suites
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.TimeoutOutputCaptureTest",
+    deps = [
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
     ] + junit5_deps("contrib_rules_jvm_tests"),
 )

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BazelJUnitOutputListenerTest.java
@@ -458,6 +458,40 @@ public class BazelJUnitOutputListenerTest {
     assertEquals("[engine:mocked]/[class:ExampleTest]/[method:Weird&#8;name()]", testName);
   }
 
+  @Test
+  void testFallbackStdoutUsedWhenPrimaryNull() {
+    TestData test = new TestData(identifier);
+    test.setFallbackStdOut("fallback output");
+
+    assertEquals("fallback output", test.getStdOut());
+  }
+
+  @Test
+  void testPrimaryStdoutPreferredOverFallback() {
+    TestData test = new TestData(identifier);
+    test.addReportEntry(ReportEntry.from(STDOUT_REPORT_ENTRY_KEY, "primary output"));
+    test.setFallbackStdOut("fallback output");
+
+    assertEquals("primary output", test.getStdOut());
+  }
+
+  @Test
+  void testFallbackStderrUsedWhenPrimaryNull() {
+    TestData test = new TestData(identifier);
+    test.setFallbackStdErr("fallback error");
+
+    assertEquals("fallback error", test.getStdErr());
+  }
+
+  @Test
+  void testPrimaryStderrPreferredOverFallback() {
+    TestData test = new TestData(identifier);
+    test.addReportEntry(ReportEntry.from(STDERR_REPORT_ENTRY_KEY, "primary error"));
+    test.setFallbackStdErr("fallback error");
+
+    assertEquals("primary error", test.getStdErr());
+  }
+
   private Document generateTestXml(TestPlan testPlan, TestData testCase) {
     return generateDocument(xml -> new TestCaseXmlRenderer(testPlan).toXml(xml, testCase));
   }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/OutputCaptureTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/OutputCaptureTest.java
@@ -1,0 +1,119 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OutputCaptureTest {
+
+  private PrintStream originalOut;
+  private PrintStream originalErr;
+
+  @BeforeEach
+  void setUp() {
+    originalOut = System.out;
+    originalErr = System.err;
+  }
+
+  @AfterEach
+  void tearDown() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @Test
+  void testCapturesStdout() {
+    OutputCapture capture = new OutputCapture();
+    capture.start();
+
+    System.out.print("hello");
+
+    capture.stop();
+
+    assertTrue(capture.hasStdout());
+    assertEquals("hello", capture.getStdout());
+  }
+
+  @Test
+  void testCapturesStderr() {
+    OutputCapture capture = new OutputCapture();
+    capture.start();
+
+    System.err.print("error message");
+
+    capture.stop();
+
+    assertTrue(capture.hasStderr());
+    assertEquals("error message", capture.getStderr());
+  }
+
+  @Test
+  void testRestoresOriginalStreams() {
+    // Use assertSame with inline references to avoid PMD CloseResource false positive
+    OutputCapture capture = new OutputCapture();
+    assertSame(originalOut, System.out, "stdout should match before start");
+    assertSame(originalErr, System.err, "stderr should match before start");
+
+    capture.start();
+    capture.stop();
+
+    assertSame(originalOut, System.out, "stdout should be restored after stop");
+    assertSame(originalErr, System.err, "stderr should be restored after stop");
+  }
+
+  @Test
+  void testIdempotentStartStop() {
+    OutputCapture capture = new OutputCapture();
+
+    // Multiple starts should be safe
+    capture.start();
+    capture.start();
+
+    System.out.print("test");
+
+    // Multiple stops should be safe
+    capture.stop();
+    capture.stop();
+
+    assertEquals("test", capture.getStdout());
+  }
+
+  @Test
+  void testEmptyCapture() {
+    OutputCapture capture = new OutputCapture();
+    capture.start();
+    capture.stop();
+
+    assertFalse(capture.hasStdout());
+    assertFalse(capture.hasStderr());
+    assertEquals("", capture.getStdout());
+    assertEquals("", capture.getStderr());
+  }
+
+  @Test
+  void testOutputStillGoesToOriginalStream() {
+    // Capture the original stdout to a buffer
+    ByteArrayOutputStream originalBuffer = new ByteArrayOutputStream();
+    PrintStream testOut = new PrintStream(originalBuffer, true, UTF_8);
+    System.setOut(testOut);
+
+    OutputCapture capture = new OutputCapture();
+    capture.start();
+
+    System.out.print("dual output");
+
+    capture.stop();
+
+    // Both our capture and the "original" (our test buffer) should have the output
+    assertEquals("dual output", capture.getStdout());
+    assertEquals("dual output", originalBuffer.toString(UTF_8));
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TimeoutOutputCaptureTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/TimeoutOutputCaptureTest.java
@@ -1,0 +1,29 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Integration test that intentionally times out to verify stdout capture.
+ *
+ * <p>Run with: bazel test //java/test/.../junit5:timeout-output-capture-test --test_timeout=3
+ *
+ * <p>Then check test.xml for system-out containing the log lines.
+ *
+ * <p>This test is marked manual so it doesn't run in normal test suites.
+ */
+public class TimeoutOutputCaptureTest {
+
+  @Test
+  void testOutputCapturedOnTimeout() throws InterruptedException {
+    System.out.println("[TIMEOUT-TEST] Starting test");
+    System.out.println("[TIMEOUT-TEST] Line 1");
+    System.out.println("[TIMEOUT-TEST] Line 2");
+    System.out.flush();
+
+    // Sleep longer than the test timeout
+    Thread.sleep(60_000);
+
+    // This should never be reached
+    System.out.println("[TIMEOUT-TEST] ERROR: Test completed without timeout!");
+  }
+}


### PR DESCRIPTION
When a test times out, stdout/stderr output that was already written is now captured and included in the test report XML. This helps diagnose timeout issues by preserving any logging or print statements that occurred before the timeout interrupt.

The current behavior only shows `Test timed out and was interrupted`

Edit: This is probably still not a great solution because the "fallback" stream has the logs from every test case.