### PR TITLE
[gazelle]: Fix missed Java deps from static calls on bare class names

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -425,8 +425,8 @@ public class ClasspathParser {
       if (receiverTypeName == null) {
         return;
       }
-      // Imported identifiers are known types even when they are acronym-style names
-      // (for example UUID), which our heuristic would otherwise reject.
+      // Imported identifiers are known types even when they are acronym-style
+      // names (for example UUID), which our heuristic would otherwise reject.
       if (currentFileImports.containsKey(receiverTypeName)
           || looksLikeClassName(receiverTypeName)) {
         checkFullyQualifiedType(container);

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -572,8 +572,7 @@ public class ClasspathParserTest {
                 "/workspace/com/gazelle/java/javaparser/generators/SamePackageStaticCall.java"));
     ParsedPackageData data = parser.parseClasses(files);
     assertEquals(
-        Set.of("workspace.com.gazelle.java.javaparser.generators.ExternalFactory"),
-        data.usedTypes);
+        Set.of("workspace.com.gazelle.java.javaparser.generators.ExternalFactory"), data.usedTypes);
   }
 
   @Test

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -564,6 +564,28 @@ public class ClasspathParserTest {
     }
   }
 
+  @Test
+  public void testSamePackageStaticMethodCall() throws IOException {
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/SamePackageStaticCall.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+    assertEquals(
+        Set.of("workspace.com.gazelle.java.javaparser.generators.ExternalFactory"),
+        data.usedTypes);
+  }
+
+  @Test
+  public void testImportedAcronymStaticMethodCall() throws IOException {
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/ImportedAcronymStaticCall.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+    assertEquals(Set.of("java.util.UUID"), data.usedTypes);
+  }
+
   private <T> TreeSet<T> treeSet(T... values) {
     return new TreeSet<>(Arrays.asList(values));
   }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/ImportedAcronymStaticCall.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/ImportedAcronymStaticCall.java
@@ -1,0 +1,7 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+import java.util.UUID;
+
+public class ImportedAcronymStaticCall {
+  Object id = UUID.randomUUID();
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/SamePackageStaticCall.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/SamePackageStaticCall.java
@@ -1,0 +1,6 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+public class SamePackageStaticCall {
+    Object result = ExternalFactory.create(42);
+    Object other = ExternalFactory.build("test", new Object());
+}


### PR DESCRIPTION
Gazelle was missing valid Java dependencies when static methods were called on bare class identifiers, especially in same-package references and imported acronym-style types like `UUID`. This caused underreported `usedTypes`, which can lead to incorrect dependency inference.

This change closes that gap so dependency detection better matches real Java usage patterns and avoids silently dropping required deps in common static-call code paths.