### PR TITLE
Fix checkstyle binary transition

### DIFF
--- a/java/private/checkstyle.bzl
+++ b/java/private/checkstyle.bzl
@@ -70,6 +70,7 @@ _checkstyle_test = rule(
             providers = [
                 [CheckStyleInfo],
             ],
+            cfg = "target",
         ),
         "xslt": attr.label(
             doc = "Path to the checkstyle2junit.xslt file",
@@ -79,7 +80,7 @@ _checkstyle_test = rule(
         "_xslt_transformer": attr.label(
             default = "@contrib_rules_jvm//java/src/com/github/bazel_contrib/contrib_rules_jvm/xml:XSLTTransformer",
             executable = True,
-            cfg = "exec",
+            cfg = "target",
         ),
     },
     executable = True,

--- a/java/private/checkstyle_config.bzl
+++ b/java/private/checkstyle_config.bzl
@@ -91,7 +91,7 @@ checkstyle_config = rule(
             doc = "Checkstyle binary to use.",
             default = "@contrib_rules_jvm//java:checkstyle_cli",
             executable = True,
-            cfg = "exec",
+            cfg = "target",
             providers = [
                 JavaInfo,
             ],


### PR DESCRIPTION
This PR fixes an issue when a client build with remote in case an exec platform is different (aarch64 -> amd64 -> aarch64)

We need to bring a correct configuration for checkstyle binary that will be executed on a **target** platform

Without this change, you will get:

```
...-checkstyleexec.runfiles/rules_java++toolchains+remotejdk25_linux/bin/java: cannot execute binary file
```