### PR TITLE
[javaparser] Unify `isLikelyClassName` into shared `ClassNames`

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 java_library(
     name = "generators",
     srcs = [
+        "ClassNames.java",
         "ClasspathParser.java",
         "GrpcServer.java",
         "JavaIdentifier.java",

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClassNames.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClassNames.java
@@ -1,0 +1,45 @@
+package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
+
+/**
+ * Shared heuristics for deciding whether a simple name looks like a class name (PascalCase) vs. a
+ * constant, type parameter, or other identifier.
+ */
+final class ClassNames {
+
+  private ClassNames() {}
+
+  /**
+   * Returns true if the given simple name looks like a PascalCase class name.
+   *
+   * <p>Returns false for: empty strings, names that don't start with an uppercase letter, single
+   * uppercase characters (likely type parameters), and ALL_CAPS_SNAKE_CASE constants.
+   */
+  static boolean isLikelyClassName(String name) {
+    if (name.isEmpty()) {
+      return false;
+    }
+    if (!firstLetterIsUppercase(name)) {
+      return false;
+    }
+    // Check that there is at least one lowercase letter after the first character.
+    // This rejects single uppercase chars (type parameters like T) and
+    // ALL_CAPS / SCREAMING_SNAKE_CASE constants.
+    for (int i = 1; i < name.length(); i++) {
+      char c = name.charAt(i);
+      if (Character.isLetter(c) && Character.isLowerCase(c)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean firstLetterIsUppercase(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (Character.isLetter(c)) {
+        return Character.isUpperCase(c);
+      }
+    }
+    return false;
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -1,5 +1,6 @@
 package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
+import static com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators.ClassNames.isLikelyClassName;
 import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
@@ -427,22 +428,7 @@ public class ClasspathParser {
     }
 
     private boolean looksLikeClassName(String identifier) {
-      if (identifier.isEmpty()) {
-        return false;
-      }
-      // Classes start with UpperCase.
-      if (!Character.isUpperCase(identifier.charAt(0))) {
-        return false;
-      }
-      // Single-char upper-case may well be a class-name.
-      if (identifier.length() == 1) {
-        return true;
-      }
-      // SNAKE_CASE is for constants not classes.
-      if (identifier.chars().allMatch(c -> Character.isUpperCase(c) || c == '_')) {
-        return false;
-      }
-      return true;
+      return isLikelyClassName(identifier);
     }
 
     @Override

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -1,5 +1,7 @@
 package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
+import static com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators.ClassNames.isLikelyClassName;
+
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -837,33 +839,6 @@ public class KtParser {
 
     private FqName packageRelativeName(FqName name, KtFile file) {
       return FqNamesUtilKt.tail(name, file.getPackageFqName());
-    }
-
-    /** Returns true if this simple name is PascalCase. */
-    private boolean isLikelyClassName(String name) {
-      if (name.isEmpty() || !firstLetterIsUppercase(name)) {
-        return false;
-      }
-      // If the name is all uppercase, assume it's a constant. At worst, we'll still
-      // import the package, which seems a safer default than assuming it's a class
-      // that we then can't find.
-      for (int i = 1; i < name.length(); i++) {
-        char c = name.charAt(i);
-        if (Character.isLetter(c) && Character.isLowerCase(c)) {
-          return true;
-        }
-      }
-      return false;
-    }
-
-    private boolean firstLetterIsUppercase(String value) {
-      for (int i = 0; i < value.length(); i++) {
-        char c = value.charAt(i);
-        if (Character.isLetter(c)) {
-          return Character.isUpperCase(c);
-        }
-      }
-      return false;
     }
 
     private Optional<KtNamedFunction> retrievePossibleMainFunction(KtObjectDeclaration object) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -6,6 +6,7 @@ java_test_suite(
     name = "generators",
     size = "small",
     srcs = [
+        "ClassNamesTest.java",
         "ClasspathParserTest.java",
         "JavaIdentifierTest.java",
         "KtParserTest.java",

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClassNamesTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClassNamesTest.java
@@ -1,0 +1,51 @@
+package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
+
+import static com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators.ClassNames.isLikelyClassName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class ClassNamesTest {
+
+  @Test
+  void pascalCaseNamesAreClassNames() {
+    assertTrue(isLikelyClassName("String"));
+    assertTrue(isLikelyClassName("ArrayList"));
+    assertTrue(isLikelyClassName("KtParser"));
+    assertTrue(isLikelyClassName("IOException"));
+  }
+
+  @Test
+  void emptyStringIsNotClassName() {
+    assertFalse(isLikelyClassName(""));
+  }
+
+  @Test
+  void lowercaseStartIsNotClassName() {
+    assertFalse(isLikelyClassName("string"));
+    assertFalse(isLikelyClassName("myClass"));
+    assertFalse(isLikelyClassName("parseInt"));
+  }
+
+  @Test
+  void singleUppercaseCharIsNotClassName() {
+    // Single uppercase letters are typically type parameters (T, E, K, V)
+    assertFalse(isLikelyClassName("T"));
+    assertFalse(isLikelyClassName("E"));
+  }
+
+  @Test
+  void allCapsConstantsAreNotClassNames() {
+    assertFalse(isLikelyClassName("MAX_VALUE"));
+    assertFalse(isLikelyClassName("HTTP"));
+    assertFalse(isLikelyClassName("SQL"));
+    assertFalse(isLikelyClassName("IO"));
+  }
+
+  @Test
+  void twoCharPascalCaseIsClassName() {
+    assertTrue(isLikelyClassName("Io"));
+    assertTrue(isLikelyClassName("Ok"));
+  }
+}


### PR DESCRIPTION
Extract the PascalCase class-name heuristic used by both `ClasspathParser` and `KtParser` into a shared `ClassNames` utility class with a unit test.

The unified implementation follows the `KtParser` behavior: names must start with an uppercase letter and contain at least one lowercase letter. This rejects single uppercase chars (type parameters like T) and ALL_CAPS constants (SNAKE_CASE), which is the safer default for both languages.