### PR TITLE
[gazelle] Improve type detection in java and kotlin parsers

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -13,6 +13,7 @@ java_library(
         "ParsedPackageData.java",
         "PerClassData.java",
         "TimeoutHandler.java",
+        "TypeNameResolver.java",
     ],
     visibility = ["//java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser:__subpackages__"],
     runtime_deps = [

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -283,6 +283,15 @@ public class ClasspathParser {
       if (i.isStatic()) {
         String staticPackage = name.substring(0, name.lastIndexOf('.'));
         data.usedTypes.add(staticPackage);
+        // Static imports of nested classes (e.g., `import static Outer.Inner`) make the
+        // inner class available as a bare type. Register it in currentFileImports so
+        // that later type references resolve to the import rather than falling through
+        // to the same-package catch-all in checkFullyQualifiedType.
+        String lastComponent = name.substring(name.lastIndexOf('.') + 1);
+        if (isLikelyClassName(lastComponent)) {
+          currentFileImports.put(lastComponent, name);
+          data.usedTypes.add(name);
+        }
       } else if (name.endsWith(".*")) {
         String wildcardPackage = name.substring(0, name.lastIndexOf('.'));
         data.usedPackagesWithoutSpecificTypes.add(wildcardPackage);
@@ -307,6 +316,7 @@ public class ClasspathParser {
       for (Tree implement : t.getImplementsClause()) {
         checkFullyQualifiedType(implement);
       }
+      handleAnnotations(t.getModifiers().getAnnotations());
       for (AnnotationTree annotation : t.getModifiers().getAnnotations()) {
         String annotationClassName = annotation.getAnnotationType().toString();
         String importedFullyQualified = currentFileImports.get(annotationClassName);
@@ -397,18 +407,45 @@ public class ClasspathParser {
     public Void visitMethodInvocation(MethodInvocationTree node, Void v) {
       if (node.getMethodSelect() instanceof MemberSelectTree) {
         ExpressionTree container = ((MemberSelectTree) node.getMethodSelect()).getExpression();
-        if (container instanceof MemberSelectTree) {
-          MemberSelectTree containerMST = (MemberSelectTree) container;
-          if (looksLikeClassName(containerMST.getIdentifier().toString())) {
-            checkFullyQualifiedType(container);
-          }
-        }
+        maybeRecordMethodReceiverType(container);
       }
       return super.visitMethodInvocation(node, v);
     }
 
+    private void maybeRecordMethodReceiverType(ExpressionTree container) {
+      String receiverTypeName = methodReceiverTypeName(container);
+      if (receiverTypeName == null) {
+        return;
+      }
+      // Imported identifiers are known types even when they are acronym-style names
+      // (for example UUID), which our heuristic would otherwise reject.
+      if (currentFileImports.containsKey(receiverTypeName) || looksLikeClassName(receiverTypeName)) {
+        checkFullyQualifiedType(container);
+      }
+    }
+
+    @Nullable
+    private String methodReceiverTypeName(ExpressionTree container) {
+      if (container instanceof MemberSelectTree) {
+        return ((MemberSelectTree) container).getIdentifier().toString();
+      }
+      if (container.getKind() == Tree.Kind.IDENTIFIER) {
+        return container.toString();
+      }
+      return null;
+    }
+
     private boolean looksLikeClassName(String identifier) {
       return isLikelyClassName(identifier);
+    }
+
+    @Override
+    public Void visitMemberSelect(MemberSelectTree node, Void v) {
+      // Foo.class — the expression part is a type reference.
+      if (node.getIdentifier().toString().equals("class")) {
+        checkFullyQualifiedType(node.getExpression());
+      }
+      return super.visitMemberSelect(node, v);
     }
 
     @Override
@@ -422,6 +459,8 @@ public class ClasspathParser {
       if (node.getType() != null) {
         checkFullyQualifiedType(node.getType());
       }
+
+      handleAnnotations(node.getModifiers().getAnnotations());
 
       // Local variables inside methods shouldn't be treated as fields.
       if (isDirectlyInClass()) {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -419,7 +419,8 @@ public class ClasspathParser {
       }
       // Imported identifiers are known types even when they are acronym-style names
       // (for example UUID), which our heuristic would otherwise reject.
-      if (currentFileImports.containsKey(receiverTypeName) || looksLikeClassName(receiverTypeName)) {
+      if (currentFileImports.containsKey(receiverTypeName)
+          || looksLikeClassName(receiverTypeName)) {
         checkFullyQualifiedType(container);
       }
     }
@@ -498,7 +499,10 @@ public class ClasspathParser {
           || identifier.getKind() == Tree.Kind.MEMBER_SELECT) {
         Optional<String> resolved =
             TypeNameResolver.resolve(
-                identifier.toString(), currentFileImports, currentPackage, excludedSamePackageNames());
+                identifier.toString(),
+                currentFileImports,
+                currentPackage,
+                excludedSamePackageNames());
         if (resolved.isPresent()) {
           data.usedTypes.add(resolved.get());
           types.add(resolved.get());

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -6,7 +6,6 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.ArrayTypeTree;
@@ -35,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -481,6 +481,13 @@ public class ClasspathParser {
       return super.visitVariable(node, unused);
     }
 
+    private Set<String> excludedSamePackageNames() {
+      Set<String> excluded = new TreeSet<>(JAVA_LANG_TYPES);
+      excluded.addAll(locallyDefinedClassNames);
+      excluded.addAll(typeParameterNames);
+      return excluded;
+    }
+
     @Nullable
     private Set<String> checkFullyQualifiedType(Tree identifier) {
       if (identifier == null) {
@@ -489,27 +496,12 @@ public class ClasspathParser {
       Set<String> types = new TreeSet<>();
       if (identifier.getKind() == Tree.Kind.IDENTIFIER
           || identifier.getKind() == Tree.Kind.MEMBER_SELECT) {
-        String typeName = identifier.toString();
-        List<String> components = Splitter.on(".").splitToList(typeName);
-        if (currentFileImports.containsKey(components.get(0))) {
-          String importedType = currentFileImports.get(components.get(0));
-          data.usedTypes.add(importedType);
-          types.add(importedType);
-        } else if (components.size() > 1) {
-          data.usedTypes.add(typeName);
-          types.add(typeName);
-        } else if (currentPackage != null
-            && !typeName.isEmpty()
-            && !locallyDefinedClassNames.contains(typeName)
-            && !JAVA_LANG_TYPES.contains(typeName)
-            && !typeParameterNames.contains(typeName)) {
-          // Bare class name, not imported, not locally defined — resolve against
-          // current package. This handles same-package references like
-          // "extends AbstractIdentifier" where the referenced class is in the
-          // same Java package but potentially a different Bazel package.
-          String qualifiedName = currentPackage + "." + typeName;
-          data.usedTypes.add(qualifiedName);
-          types.add(qualifiedName);
+        Optional<String> resolved =
+            TypeNameResolver.resolve(
+                identifier.toString(), currentFileImports, currentPackage, excludedSamePackageNames());
+        if (resolved.isPresent()) {
+          data.usedTypes.add(resolved.get());
+          types.add(resolved.get());
         }
       } else if (identifier.getKind() == Tree.Kind.PARAMETERIZED_TYPE) {
         Tree baseType = ((ParameterizedTypeTree) identifier).getType();

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -103,11 +103,42 @@ public class KtParser {
     return conf;
   }
 
+  // Auto-imported names from kotlin.*, kotlin.collections.*, kotlin.io.* etc. These should
+  // not trigger the same-package fallback in the resolver. Only the bare simple names that
+  // can appear in source without an explicit import are listed.
+  private static final Set<String> KOTLIN_WELL_KNOWN_TYPES =
+      Set.of(
+          // Type system
+          "Any", "Nothing", "Unit",
+          // Primitive wrappers
+          "Boolean", "Byte", "Char", "Double", "Float", "Int", "Long", "Short",
+          // Strings / text
+          "CharSequence", "String",
+          // Numbers / arrays
+          "Number", "Array",
+          "BooleanArray", "ByteArray", "CharArray", "DoubleArray", "FloatArray",
+          "IntArray", "LongArray", "ShortArray",
+          // Throwables
+          "Throwable", "Exception", "Error", "RuntimeException",
+          "IllegalArgumentException", "IllegalStateException", "NullPointerException",
+          "UnsupportedOperationException", "IndexOutOfBoundsException", "ClassCastException",
+          // Common types
+          "Comparable", "Cloneable", "Enum", "Lazy", "Pair", "Triple",
+          // kotlin.collections
+          "Collection", "MutableCollection",
+          "Iterable", "MutableIterable",
+          "Iterator", "MutableIterator",
+          "List", "MutableList",
+          "ListIterator", "MutableListIterator",
+          "Map", "MutableMap",
+          "Set", "MutableSet",
+          "Sequence");
+
   public static class KtFileVisitor extends KtTreeVisitorVoid {
     final ParsedPackageData packageData = new ParsedPackageData();
 
     private Stack<Visibility> visibilityStack = new Stack<>();
-    private HashMap<String, FqName> fqImportByNameOrAlias = new HashMap<>();
+    private HashMap<String, String> fqImportByNameOrAlias = new HashMap<>();
 
     // Track inline functions and their dependencies
     private String currentInlineFunction = null;
@@ -178,7 +209,7 @@ public class KtParser {
           localName = className.shortName().toString();
         }
         packageData.usedTypes.add(className.toString());
-        fqImportByNameOrAlias.put(localName, className);
+        fqImportByNameOrAlias.put(localName, className.toString());
       } else {
         if (importDirective.isAllUnder()) {
           // If it's a wildcard import with no obvious class name, assume it's a package.
@@ -418,15 +449,29 @@ public class KtParser {
     public void visitTypeReference(KtTypeReference reference) {
       logger.debug("Type reference: " + reference.getText());
 
-      // FQN type references in any type position (parameters, return types, properties,
-      // supertypes, is/as casts, annotations) — reconstruct the qualifier chain and
-      // record the full type name. Simple unqualified names are already covered by
-      // the import handler.
+      // Type references in any position (parameters, return types, properties, supertypes,
+      // is/as casts, annotations) flow through the shared resolver:
+      //   - FQN names like com.example.Foo are reconstructed from the qualifier chain and
+      //     pass through as-is.
+      //   - Bare imported names resolve via the import map.
+      //   - Bare class-like names not in imports fall back to the file's package
+      //     (split-package case), unless they are well-known kotlin.* types.
+      // Generic type arguments are KtTypeReference children and are visited via super.
       KtTypeElement rootType = getRootType(reference);
       if (rootType instanceof KtUserType) {
         KtUserType userType = (KtUserType) rootType;
-        if (userType.getQualifier() != null) {
-          packageData.usedTypes.add(reconstructQualifiedName(userType));
+        String name =
+            userType.getQualifier() != null
+                ? reconstructQualifiedName(userType)
+                : userType.getReferencedName();
+        // Gate by isLikelyClassName for bare names so type parameters and other identifiers
+        // don't trigger the same-package fallback. FQN names always have dots and pass through.
+        if (name != null && (name.contains(".") || isLikelyClassName(name))) {
+          FqName filePackage = reference.getContainingKtFile().getPackageFqName();
+          String currentPackage = filePackage.isRoot() ? null : filePackage.asString();
+          TypeNameResolver.resolve(
+                  name, fqImportByNameOrAlias, currentPackage, KOTLIN_WELL_KNOWN_TYPES)
+              .ifPresent(packageData.usedTypes::add);
         }
       }
 
@@ -465,7 +510,7 @@ public class KtParser {
         return;
       }
       if (fqImportByNameOrAlias.containsKey(referencedName)) {
-        String fqName = fqImportByNameOrAlias.get(referencedName).toString();
+        String fqName = fqImportByNameOrAlias.get(referencedName);
         deps.add(fqName);
         logger.debug(context + " uses class: " + fqName);
       } else if (referencedName.contains(".")) {
@@ -669,7 +714,7 @@ public class KtParser {
     private String resolveTypeToFqName(String typeName) {
       // Try to resolve using imports
       if (fqImportByNameOrAlias.containsKey(typeName)) {
-        return fqImportByNameOrAlias.get(typeName).toString();
+        return fqImportByNameOrAlias.get(typeName);
       }
 
       // If it's already fully qualified, return as-is
@@ -762,7 +807,7 @@ public class KtParser {
         String name = simpleExpr.getReferencedName();
 
         if (fqImportByNameOrAlias.containsKey(name)) {
-          return fqImportByNameOrAlias.get(name).toString();
+          return fqImportByNameOrAlias.get(name);
         }
 
         switch (name) {
@@ -859,7 +904,7 @@ public class KtParser {
         }
         String identifier = userType.getReferencedName();
         if (fqImportByNameOrAlias.containsKey(identifier)) {
-          return Optional.of(fqImportByNameOrAlias.get(identifier).toString());
+          return Optional.of(fqImportByNameOrAlias.get(identifier));
         }
         return Optional.empty();
       }
@@ -872,18 +917,16 @@ public class KtParser {
         return;
       }
       String name = ((KtSimpleNameExpression) receiverExpression).getReferencedName();
+      // The DQE visitor fires for non-class receivers too (someObject.method()), so the
+      // class-name heuristic is the gate that decides whether to consult the resolver.
       if (!isLikelyClassName(name)) {
         return;
       }
-      // If the name is imported, the import handler already recorded it.
-      if (fqImportByNameOrAlias.containsKey(name)) {
-        return;
-      }
       FqName filePackage = contextElement.getContainingKtFile().getPackageFqName();
-      if (filePackage.isRoot()) {
-        return;
-      }
-      packageData.usedTypes.add(filePackage.child(Name.identifier(name)).asString());
+      String currentPackage = filePackage.isRoot() ? null : filePackage.asString();
+      TypeNameResolver.resolve(
+              name, fqImportByNameOrAlias, currentPackage, KOTLIN_WELL_KNOWN_TYPES)
+          .ifPresent(packageData.usedTypes::add);
     }
 
     private String reconstructQualifiedName(KtUserType userType) {
@@ -916,7 +959,7 @@ public class KtParser {
 
       // Try to resolve to fully qualified name if it's in imports
       if (fqImportByNameOrAlias.containsKey(typeText)) {
-        return fqImportByNameOrAlias.get(typeText).toString();
+        return fqImportByNameOrAlias.get(typeText);
       }
 
       // For built-in types like String, Int, etc., add java.lang prefix if needed
@@ -1027,7 +1070,7 @@ public class KtParser {
 
           // Try to resolve from imports
           if (fqImportByNameOrAlias.containsKey(calleeName)) {
-            return fqImportByNameOrAlias.get(calleeName).toString();
+            return fqImportByNameOrAlias.get(calleeName);
           }
 
           // Return the simple name as a fallback

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -109,29 +109,65 @@ public class KtParser {
   private static final Set<String> KOTLIN_WELL_KNOWN_TYPES =
       Set.of(
           // Type system
-          "Any", "Nothing", "Unit",
+          "Any",
+          "Nothing",
+          "Unit",
           // Primitive wrappers
-          "Boolean", "Byte", "Char", "Double", "Float", "Int", "Long", "Short",
+          "Boolean",
+          "Byte",
+          "Char",
+          "Double",
+          "Float",
+          "Int",
+          "Long",
+          "Short",
           // Strings / text
-          "CharSequence", "String",
+          "CharSequence",
+          "String",
           // Numbers / arrays
-          "Number", "Array",
-          "BooleanArray", "ByteArray", "CharArray", "DoubleArray", "FloatArray",
-          "IntArray", "LongArray", "ShortArray",
+          "Number",
+          "Array",
+          "BooleanArray",
+          "ByteArray",
+          "CharArray",
+          "DoubleArray",
+          "FloatArray",
+          "IntArray",
+          "LongArray",
+          "ShortArray",
           // Throwables
-          "Throwable", "Exception", "Error", "RuntimeException",
-          "IllegalArgumentException", "IllegalStateException", "NullPointerException",
-          "UnsupportedOperationException", "IndexOutOfBoundsException", "ClassCastException",
+          "Throwable",
+          "Exception",
+          "Error",
+          "RuntimeException",
+          "IllegalArgumentException",
+          "IllegalStateException",
+          "NullPointerException",
+          "UnsupportedOperationException",
+          "IndexOutOfBoundsException",
+          "ClassCastException",
           // Common types
-          "Comparable", "Cloneable", "Enum", "Lazy", "Pair", "Triple",
+          "Comparable",
+          "Cloneable",
+          "Enum",
+          "Lazy",
+          "Pair",
+          "Triple",
           // kotlin.collections
-          "Collection", "MutableCollection",
-          "Iterable", "MutableIterable",
-          "Iterator", "MutableIterator",
-          "List", "MutableList",
-          "ListIterator", "MutableListIterator",
-          "Map", "MutableMap",
-          "Set", "MutableSet",
+          "Collection",
+          "MutableCollection",
+          "Iterable",
+          "MutableIterable",
+          "Iterator",
+          "MutableIterator",
+          "List",
+          "MutableList",
+          "ListIterator",
+          "MutableListIterator",
+          "Map",
+          "MutableMap",
+          "Set",
+          "MutableSet",
           "Sequence");
 
   public static class KtFileVisitor extends KtTreeVisitorVoid {
@@ -924,8 +960,7 @@ public class KtParser {
       }
       FqName filePackage = contextElement.getContainingKtFile().getPackageFqName();
       String currentPackage = filePackage.isRoot() ? null : filePackage.asString();
-      TypeNameResolver.resolve(
-              name, fqImportByNameOrAlias, currentPackage, KOTLIN_WELL_KNOWN_TYPES)
+      TypeNameResolver.resolve(name, fqImportByNameOrAlias, currentPackage, KOTLIN_WELL_KNOWN_TYPES)
           .ifPresent(packageData.usedTypes::add);
     }
 

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -418,6 +418,18 @@ public class KtParser {
     public void visitTypeReference(KtTypeReference reference) {
       logger.debug("Type reference: " + reference.getText());
 
+      // FQN type references in any type position (parameters, return types, properties,
+      // supertypes, is/as casts, annotations) — reconstruct the qualifier chain and
+      // record the full type name. Simple unqualified names are already covered by
+      // the import handler.
+      KtTypeElement rootType = getRootType(reference);
+      if (rootType instanceof KtUserType) {
+        KtUserType userType = (KtUserType) rootType;
+        if (userType.getQualifier() != null) {
+          packageData.usedTypes.add(reconstructQualifiedName(userType));
+        }
+      }
+
       super.visitTypeReference(reference);
     }
 
@@ -515,14 +527,37 @@ public class KtParser {
       logger.debug("AST: Dot qualified expression: " + expression.getText());
 
       KtExpression selectorExpression = expression.getSelectorExpression();
+      KtExpression receiverExpression = expression.getReceiverExpression();
       if (selectorExpression instanceof KtCallExpression) {
         KtCallExpression callExpr = (KtCallExpression) selectorExpression;
-        KtExpression receiverExpression = expression.getReceiverExpression();
         if (receiverExpression != null && callExpr.getCalleeExpression() != null) {
           String receiverType = getSimpleExpressionType(receiverExpression);
           String functionName = callExpr.getCalleeExpression().getText();
 
           checkExtensionFunctionCall(receiverType, functionName);
+
+          // FQN constructor / static call: com.example.ClassName(args) or
+          // com.example.ClassName.fn() — when the call's name is a class-like
+          // identifier and the receiver chain has dots, record the full qualified type.
+          if (isLikelyClassName(functionName) && receiverExpression.getText().contains(".")) {
+            packageData.usedTypes.add(receiverExpression.getText() + "." + functionName);
+          }
+        }
+
+        // Same-package bare class method receiver: SamePackageHelper.create() —
+        // a single class-like identifier as the receiver, with no import. This
+        // matters for split packages where the class lives in a different Bazel target.
+        recordSamePackageReceiverIfBareClass(receiverExpression, expression);
+      } else if (selectorExpression instanceof KtSimpleNameExpression) {
+        // FQN class reference as the selector of a DQE chain:
+        // com.example.ClassName.staticMember or com.example.ClassName.staticMethod()
+        // is parsed as outer-DQE(receiver=com.example.ClassName, selector=staticMethod()),
+        // and the inner DQE here has receiver=com.example, selector=ClassName.
+        String selectorName = ((KtSimpleNameExpression) selectorExpression).getReferencedName();
+        if (isLikelyClassName(selectorName)
+            && receiverExpression != null
+            && receiverExpression.getText().contains(".")) {
+          packageData.usedTypes.add(receiverExpression.getText() + "." + selectorName);
         }
       }
 
@@ -818,19 +853,50 @@ public class KtParser {
     private Optional<String> tryGetFullyQualifiedName(KtTypeElement typeElement) {
       if (typeElement instanceof KtUserType) {
         KtUserType userType = (KtUserType) typeElement;
-        String identifier = userType.getReferencedName();
-        if (identifier.contains(".")) {
-          return Optional.of(identifier);
-        } else {
-          if (fqImportByNameOrAlias.containsKey(identifier)) {
-            return Optional.of(fqImportByNameOrAlias.get(identifier).toString());
-          } else {
-            return Optional.empty();
-          }
+        // FQN type with a qualifier chain (e.g. com.example.Foo): walk the chain.
+        if (userType.getQualifier() != null) {
+          return Optional.of(reconstructQualifiedName(userType));
         }
-      } else {
+        String identifier = userType.getReferencedName();
+        if (fqImportByNameOrAlias.containsKey(identifier)) {
+          return Optional.of(fqImportByNameOrAlias.get(identifier).toString());
+        }
         return Optional.empty();
       }
+      return Optional.empty();
+    }
+
+    private void recordSamePackageReceiverIfBareClass(
+        KtExpression receiverExpression, KtElement contextElement) {
+      if (!(receiverExpression instanceof KtSimpleNameExpression)) {
+        return;
+      }
+      String name = ((KtSimpleNameExpression) receiverExpression).getReferencedName();
+      if (!isLikelyClassName(name)) {
+        return;
+      }
+      // If the name is imported, the import handler already recorded it.
+      if (fqImportByNameOrAlias.containsKey(name)) {
+        return;
+      }
+      FqName filePackage = contextElement.getContainingKtFile().getPackageFqName();
+      if (filePackage.isRoot()) {
+        return;
+      }
+      packageData.usedTypes.add(filePackage.child(Name.identifier(name)).asString());
+    }
+
+    private String reconstructQualifiedName(KtUserType userType) {
+      java.util.Deque<String> parts = new java.util.ArrayDeque<>();
+      KtUserType current = userType;
+      while (current != null) {
+        String name = current.getReferencedName();
+        if (name != null) {
+          parts.addFirst(name);
+        }
+        current = current.getQualifier();
+      }
+      return String.join(".", parts);
     }
 
     private FqName javaClassNameForKtFile(KtFile file) {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolver.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolver.java
@@ -1,0 +1,54 @@
+package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Resolves a (possibly dotted) simple-name string to its fully-qualified form, using imports,
+ * already-qualified shape, or a same-package fallback. AST-agnostic so the policy is identical for
+ * Java and Kotlin sources — visitors are responsible for extracting the name string and deciding
+ * when to call.
+ */
+final class TypeNameResolver {
+
+  private TypeNameResolver() {}
+
+  /**
+   * @param typeName a name such as {@code Foo}, {@code Outer.Inner}, or {@code com.example.Foo}
+   * @param imports map from simple name (or alias) to fully-qualified name
+   * @param currentPackage the file's own package; null or empty disables the same-package fallback
+   * @param excluded names that should NOT trigger the same-package fallback (e.g. java.lang
+   *     built-ins, locally-defined classes, type parameters)
+   * @return the resolved fully-qualified name, or empty if no policy applies
+   */
+  static Optional<String> resolve(
+      String typeName,
+      Map<String, String> imports,
+      @Nullable String currentPackage,
+      Set<String> excluded) {
+    if (typeName == null || typeName.isEmpty()) {
+      return Optional.empty();
+    }
+    int firstDot = typeName.indexOf('.');
+    String firstSegment = firstDot == -1 ? typeName : typeName.substring(0, firstDot);
+    // An import covering the leading segment wins. Trailing components past the imported name
+    // are dropped (preserves existing ClasspathParser behaviour for inputs like "Outer.Inner"
+    // where Outer is imported).
+    if (imports.containsKey(firstSegment)) {
+      return Optional.of(imports.get(firstSegment));
+    }
+    if (firstDot != -1) {
+      // Already FQN-shaped; trust it.
+      return Optional.of(typeName);
+    }
+    if (excluded.contains(typeName)) {
+      return Optional.empty();
+    }
+    if (currentPackage == null || currentPackage.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.of(currentPackage + "." + typeName);
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolver.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolver.java
@@ -1,15 +1,14 @@
 package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
-import javax.annotation.Nullable;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import javax.annotation.Nullable;
 
 /**
  * Resolves a (possibly dotted) simple-name string to its fully-qualified form, using imports,
- * already-qualified shape, or a same-package fallback. AST-agnostic so the policy is identical for
- * Java and Kotlin sources — visitors are responsible for extracting the name string and deciding
- * when to call.
+ * already-qualified shape, or a same-package fallback. The policy is identical for Java and Kotlin
+ * sources so visitors are responsible for extracting the name string and deciding when to call.
  */
 final class TypeNameResolver {
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -10,6 +10,7 @@ java_test_suite(
         "ClasspathParserTest.java",
         "JavaIdentifierTest.java",
         "KtParserTest.java",
+        "TypeNameResolverTest.java",
     ],
     jvm_flags = [
         "-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG",

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -449,11 +449,11 @@ public class ClasspathParserTest {
 
   @Test
   public void testFqnAnnotationOnFieldAndClass() throws IOException {
-    // Gap: visitClass and visitVariable have annotation loops that call
+    // `visitClass` and `visitVariable` have annotation loops that call
     // noteAnnotatedClass/noteAnnotatedField but never call handleAnnotations,
     // so FQN annotations (e.g. @com.example.ClassAnnotation) don't get passed
     // through checkFullyQualifiedType and are invisible to dependency resolution.
-    // visitMethod does call handleAnnotations, so method-level FQN annotations work.
+    // `visitMethod` does call `handleAnnotations`, so method-level FQN annotations work.
     List<? extends JavaFileObject> files =
         List.of(
             testFiles.get(
@@ -466,27 +466,25 @@ public class ClasspathParserTest {
 
   @Test
   public void testClassLiteral() throws IOException {
-    // Gap: there is no visitMemberSelect override, so Foo.class patterns go
-    // undetected. The expression part (Foo) should be treated as a type reference.
+    // There is no `visitMemberSelect` override, so `Foo.class` patterns go
+    // undetected. The expression part (`Foo`) should be treated as a type reference.
     List<? extends JavaFileObject> files =
         List.of(
-            testFiles.get(
-                "/workspace/com/gazelle/java/javaparser/generators/ClassLiteral.java"));
+            testFiles.get("/workspace/com/gazelle/java/javaparser/generators/ClassLiteral.java"));
     ParsedPackageData data = parser.parseClasses(files);
 
     assertEquals(
         Set.of(
-            "com.example.Registry",
-            "workspace.com.gazelle.java.javaparser.generators.MyHandler"),
+            "com.example.Registry", "workspace.com.gazelle.java.javaparser.generators.MyHandler"),
         data.usedTypes);
   }
 
   @Test
   public void testBareClassMethodReceiver() throws IOException {
-    // Gap: visitMethodInvocation only handles MemberSelectTree receivers
-    // (a.B.method()), not IdentifierTree receivers (B.method()). A same-package
+    // `visitMethodInvocation` only handles MemberSelectTree receivers
+    // (`a.B.method()`), not IdentifierTree receivers (`B.method()`). A same-package
     // class used as a bare method receiver is missed because there's no import
-    // to catch it and the method-invocation path never reaches checkFullyQualifiedType.
+    // to catch it and the method-invocation path never reaches `checkFullyQualifiedType`.
     List<? extends JavaFileObject> files =
         List.of(
             testFiles.get(
@@ -500,9 +498,9 @@ public class ClasspathParserTest {
 
   @Test
   public void testStaticImportNestedClass() throws IOException {
-    // Gap: static imports register only the parent class in usedTypes but don't
-    // put the nested class name into currentFileImports. So a bare reference to
-    // Inner as a type resolves via same-package fallback instead of the import.
+    // Static imports register only the parent class in `usedTypes` but don't
+    // put the nested class name into `currentFileImports`. So a bare reference to
+    // `Inner` as a type resolves via same-package fallback instead of the import.
     List<? extends JavaFileObject> files =
         List.of(
             testFiles.get(
@@ -511,8 +509,7 @@ public class ClasspathParserTest {
 
     // Should contain the nested class FQN from the static import, not a
     // same-package fallback like workspace.com.gazelle...Inner
-    assertEquals(
-        Set.of("com.example.Outer", "com.example.Outer.Inner"), data.usedTypes);
+    assertEquals(Set.of("com.example.Outer", "com.example.Outer.Inner"), data.usedTypes);
   }
 
   private <T> TreeSet<T> treeSet(T... values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -430,7 +430,7 @@ public class ClasspathParserTest {
   @Test
   public void testSamePackageAllTypePositions() throws IOException {
     // Exercises many code paths where checkFullyQualifiedType is called:
-    // field type, method annotation, method type param bound, throws clause.
+    // class annotation, field type, method annotation, method type param bound, throws clause.
     // Also verifies filtering of type parameters (R) and java.lang types (String).
     List<? extends JavaFileObject> files =
         List.of(
@@ -439,11 +439,80 @@ public class ClasspathParserTest {
     ParsedPackageData data = parser.parseClasses(files);
     assertEquals(
         Set.of(
+            "workspace.com.gazelle.java.javaparser.generators.SomeClassAnnotation",
             "workspace.com.gazelle.java.javaparser.generators.SomeFieldType",
             "workspace.com.gazelle.java.javaparser.generators.SomeMethodAnnotation",
             "workspace.com.gazelle.java.javaparser.generators.SomeMethodBound",
             "workspace.com.gazelle.java.javaparser.generators.SomeCheckedException"),
         data.usedTypes);
+  }
+
+  @Test
+  public void testFqnAnnotationOnFieldAndClass() throws IOException {
+    // Gap: visitClass and visitVariable have annotation loops that call
+    // noteAnnotatedClass/noteAnnotatedField but never call handleAnnotations,
+    // so FQN annotations (e.g. @com.example.ClassAnnotation) don't get passed
+    // through checkFullyQualifiedType and are invisible to dependency resolution.
+    // visitMethod does call handleAnnotations, so method-level FQN annotations work.
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/FqnAnnotationOnFieldAndClass.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+
+    assertEquals(
+        Set.of("com.example.ClassAnnotation", "com.example.FieldAnnotation"), data.usedTypes);
+  }
+
+  @Test
+  public void testClassLiteral() throws IOException {
+    // Gap: there is no visitMemberSelect override, so Foo.class patterns go
+    // undetected. The expression part (Foo) should be treated as a type reference.
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/ClassLiteral.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+
+    assertEquals(
+        Set.of(
+            "com.example.Registry",
+            "workspace.com.gazelle.java.javaparser.generators.MyHandler"),
+        data.usedTypes);
+  }
+
+  @Test
+  public void testBareClassMethodReceiver() throws IOException {
+    // Gap: visitMethodInvocation only handles MemberSelectTree receivers
+    // (a.B.method()), not IdentifierTree receivers (B.method()). A same-package
+    // class used as a bare method receiver is missed because there's no import
+    // to catch it and the method-invocation path never reaches checkFullyQualifiedType.
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/BareClassMethodReceiver.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+
+    assertEquals(
+        Set.of("workspace.com.gazelle.java.javaparser.generators.SamePackageHelper"),
+        data.usedTypes);
+  }
+
+  @Test
+  public void testStaticImportNestedClass() throws IOException {
+    // Gap: static imports register only the parent class in usedTypes but don't
+    // put the nested class name into currentFileImports. So a bare reference to
+    // Inner as a type resolves via same-package fallback instead of the import.
+    List<? extends JavaFileObject> files =
+        List.of(
+            testFiles.get(
+                "/workspace/com/gazelle/java/javaparser/generators/StaticImportNestedClass.java"));
+    ParsedPackageData data = parser.parseClasses(files);
+
+    // Should contain the nested class FQN from the static import, not a
+    // same-package fallback like workspace.com.gazelle...Inner
+    assertEquals(
+        Set.of("com.example.Outer", "com.example.Outer.Inner"), data.usedTypes);
   }
 
   private <T> TreeSet<T> treeSet(T... values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
@@ -148,22 +148,103 @@ public class KtParserTest {
         data.perClassData.keySet());
   }
 
-  // @Test
-  // public void fullyQualifiedClassAndFunctionUse() throws IOException {
-  //   ParsedPackageData data = parser.parseClasses(getPathsWithNames("FullyQualifieds.kt"));
-  //   assertEquals(
-  //     Set.of("com.example"),
-  //     data.usedPackagesWithoutSpecificTypes);
-  //   assertEquals(
-  //       Set.of(
-  //           "workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest",
-  //           "workspace.com.gazelle.java.javaparser.generators.DeleteBookResponse",
-  //           "workspace.com.gazelle.java.javaparser.utils.Printer",
-  //           "workspace.com.gazelle.java.javaparser.factories.Factory",
-  //           "java.util.ArrayList",
-  //           "com.example.PrivateArg"),
-  //       data.usedTypes);
-  // }
+  @Test
+  public void testFqnExpressionsDetected() throws IOException {
+    // Gap: visitDotQualifiedExpression doesn't reconstruct FQN class references.
+    // FQN constructor calls (com.example.Foo()) and FQN static calls
+    // (com.example.Foo.method()) bypass imports entirely and are invisible.
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("FullyQualifieds.kt"));
+
+    // FQN constructor call: workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest()
+    assertTrue(
+        data.usedTypes.contains(
+            "workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest"),
+        "Should detect FQN constructor call. Found: " + data.usedTypes);
+
+    // FQN class reference: workspace.com.gazelle.java.javaparser.utils.Printer.print()
+    assertTrue(
+        data.usedTypes.contains("workspace.com.gazelle.java.javaparser.utils.Printer"),
+        "Should detect FQN class in static method call. Found: " + data.usedTypes);
+
+    // FQN class reference: workspace.com.gazelle.java.javaparser.factories.Factory.create()
+    assertTrue(
+        data.usedTypes.contains("workspace.com.gazelle.java.javaparser.factories.Factory"),
+        "Should detect FQN class in static method call. Found: " + data.usedTypes);
+
+    // FQN constructor call: java.util.ArrayList<String>()
+    assertTrue(
+        data.usedTypes.contains("java.util.ArrayList"),
+        "Should detect FQN constructor call for ArrayList. Found: " + data.usedTypes);
+  }
+
+  @Test
+  public void testFqnTypePositionsDetected() throws IOException {
+    // Gap: tryGetFullyQualifiedName calls KtUserType.getReferencedName() which returns
+    // only the last segment (e.g. "InputData"), never the full "com.example.types.InputData".
+    // The qualifier chain is never walked, so FQN types in all type positions are invisible.
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("FqnTypePositions.kt"));
+
+    // FQN function parameter type
+    assertTrue(
+        data.usedTypes.contains("com.example.types.InputData"),
+        "Should detect FQN parameter type. Found: " + data.usedTypes);
+
+    // FQN function return type
+    assertTrue(
+        data.usedTypes.contains("com.example.types.OutputData"),
+        "Should detect FQN return type. Found: " + data.usedTypes);
+
+    // FQN property type
+    assertTrue(
+        data.usedTypes.contains("com.example.config.AppConfig"),
+        "Should detect FQN property type. Found: " + data.usedTypes);
+
+    // FQN in is-check
+    assertTrue(
+        data.usedTypes.contains("com.example.types.Marker"),
+        "Should detect FQN in is-check. Found: " + data.usedTypes);
+
+    // FQN in as-cast
+    assertTrue(
+        data.usedTypes.contains("com.example.types.Castable"),
+        "Should detect FQN in as-cast. Found: " + data.usedTypes);
+  }
+
+  @Test
+  public void testFqnAnnotationsDetected() throws IOException {
+    // Gap: FQN annotations (@com.example.MyAnnotation) bypass import handling entirely.
+    // In Kotlin PSI, annotation types are KtUserType nodes with qualifier chains,
+    // but no annotation-specific handling routes them through FQN detection.
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("FqnAnnotations.kt"));
+
+    assertTrue(
+        data.usedTypes.contains("com.example.annotations.ClassAnnotation"),
+        "Should detect FQN class annotation. Found: " + data.usedTypes);
+
+    assertTrue(
+        data.usedTypes.contains("com.example.annotations.FieldAnnotation"),
+        "Should detect FQN field annotation. Found: " + data.usedTypes);
+
+    assertTrue(
+        data.usedTypes.contains("com.example.annotations.MethodAnnotation"),
+        "Should detect FQN method annotation. Found: " + data.usedTypes);
+  }
+
+  @Test
+  public void testBareClassMethodReceiver() throws IOException {
+    // Gap: KtParser relies entirely on imports for usedTypes. A same-package class
+    // used as a bare method receiver (SamePackageHelper.create()) has no import,
+    // and visitSimpleNameExpression never adds unresolved class names to usedTypes.
+    // This matters for split packages where the class is in a different Bazel target.
+    // ClasspathParser handles this via checkFullyQualifiedType's same-package fallback.
+    ParsedPackageData data =
+        parser.parseClasses(getPathsWithNames("BareClassMethodReceiver.kt"));
+
+    assertTrue(
+        data.usedTypes.contains(
+            "workspace.com.gazelle.kotlin.javaparser.generators.SamePackageHelper"),
+        "Should detect same-package bare class method receiver. Found: " + data.usedTypes);
+  }
 
   @Test
   public void staticImportsTest() throws IOException {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
@@ -150,9 +150,9 @@ public class KtParserTest {
 
   @Test
   public void testFqnExpressionsDetected() throws IOException {
-    // Gap: visitDotQualifiedExpression doesn't reconstruct FQN class references.
-    // FQN constructor calls (com.example.Foo()) and FQN static calls
-    // (com.example.Foo.method()) bypass imports entirely and are invisible.
+    // `visitDotQualifiedExpression` doesn't reconstruct FQN class references.
+    // FQN constructor calls (`com.example.Foo()`) and FQN static calls
+    // (`com.example.Foo.method()`) bypass imports entirely and are invisible.
     ParsedPackageData data = parser.parseClasses(getPathsWithNames("FullyQualifieds.kt"));
 
     // FQN constructor call: workspace.com.gazelle.java.javaparser.generators.DeleteBookRequest()
@@ -179,9 +179,9 @@ public class KtParserTest {
 
   @Test
   public void testFqnTypePositionsDetected() throws IOException {
-    // Gap: tryGetFullyQualifiedName calls KtUserType.getReferencedName() which returns
+    // `tryGetFullyQualifiedName` calls `KtUserType.getReferencedName()` which returns
     // only the last segment (e.g. "InputData"), never the full "com.example.types.InputData".
-    // The qualifier chain is never walked, so FQN types in all type positions are invisible.
+    // The qualifier chain was never walked, so FQN types in all type positions are invisible.
     ParsedPackageData data = parser.parseClasses(getPathsWithNames("FqnTypePositions.kt"));
 
     // FQN function parameter type
@@ -212,7 +212,7 @@ public class KtParserTest {
 
   @Test
   public void testFqnAnnotationsDetected() throws IOException {
-    // Gap: FQN annotations (@com.example.MyAnnotation) bypass import handling entirely.
+    // FQN annotations (`@com.example.MyAnnotation`) bypassed import handling entirely.
     // In Kotlin PSI, annotation types are KtUserType nodes with qualifier chains,
     // but no annotation-specific handling routes them through FQN detection.
     ParsedPackageData data = parser.parseClasses(getPathsWithNames("FqnAnnotations.kt"));
@@ -237,8 +237,7 @@ public class KtParserTest {
     // is-check, and as-cast should all flow through the resolver and end up in
     // usedTypes with the file's package prefixed. Built-in names like Boolean
     // and Any must not be added (kotlin.* skip list).
-    ParsedPackageData data =
-        parser.parseClasses(getPathsWithNames("SamePackageAllPositions.kt"));
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("SamePackageAllPositions.kt"));
 
     assertEquals(
         Set.of(
@@ -253,13 +252,12 @@ public class KtParserTest {
 
   @Test
   public void testBareClassMethodReceiver() throws IOException {
-    // Gap: KtParser relies entirely on imports for usedTypes. A same-package class
-    // used as a bare method receiver (SamePackageHelper.create()) has no import,
-    // and visitSimpleNameExpression never adds unresolved class names to usedTypes.
+    // `KtParser` relied entirely on imports for `usedTypes`. A same-package class
+    // used as a bare method receiver (`SamePackageHelper.create()`) has no import,
+    // and `visitSimpleNameExpression` never adds unresolved class names to `usedTypes`.
     // This matters for split packages where the class is in a different Bazel target.
-    // ClasspathParser handles this via checkFullyQualifiedType's same-package fallback.
-    ParsedPackageData data =
-        parser.parseClasses(getPathsWithNames("BareClassMethodReceiver.kt"));
+    // `ClasspathParser` handles this via `checkFullyQualifiedType`'s same-package fallback.
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("BareClassMethodReceiver.kt"));
 
     assertTrue(
         data.usedTypes.contains(

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
@@ -231,6 +231,27 @@ public class KtParserTest {
   }
 
   @Test
+  public void testSamePackageInAllTypePositions() throws IOException {
+    // Mirrors ClasspathParserTest.testSamePackageAllTypePositions: same-package
+    // class names used as supertype, field type, parameter type, return type,
+    // is-check, and as-cast should all flow through the resolver and end up in
+    // usedTypes with the file's package prefixed. Built-in names like Boolean
+    // and Any must not be added (kotlin.* skip list).
+    ParsedPackageData data =
+        parser.parseClasses(getPathsWithNames("SamePackageAllPositions.kt"));
+
+    assertEquals(
+        Set.of(
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeSuperType",
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeFieldType",
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeParamType",
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeReturnType",
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeMarker",
+            "workspace.com.gazelle.kotlin.javaparser.generators.SomeCastTarget"),
+        data.usedTypes);
+  }
+
+  @Test
   public void testBareClassMethodReceiver() throws IOException {
     // Gap: KtParser relies entirely on imports for usedTypes. A same-package class
     // used as a bare method receiver (SamePackageHelper.create()) has no import,

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolverTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolverTest.java
@@ -50,8 +50,7 @@ class TypeNameResolverTest {
 
   @Test
   void nullCurrentPackageDisablesFallback() {
-    assertEquals(
-        Optional.empty(), TypeNameResolver.resolve("Helper", Map.of(), null, Set.of()));
+    assertEquals(Optional.empty(), TypeNameResolver.resolve("Helper", Map.of(), null, Set.of()));
   }
 
   @Test
@@ -70,7 +69,6 @@ class TypeNameResolverTest {
     // gate the same-package fallback, not import resolution.
     assertEquals(
         Optional.of("java.util.UUID"),
-        TypeNameResolver.resolve(
-            "UUID", Map.of("UUID", "java.util.UUID"), "pkg", Set.of("UUID")));
+        TypeNameResolver.resolve("UUID", Map.of("UUID", "java.util.UUID"), "pkg", Set.of("UUID")));
   }
 }

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolverTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/TypeNameResolverTest.java
@@ -1,0 +1,76 @@
+package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class TypeNameResolverTest {
+
+  @Test
+  void importedSimpleNameResolvesToImportedFqn() {
+    assertEquals(
+        Optional.of("java.util.UUID"),
+        TypeNameResolver.resolve(
+            "UUID", Map.of("UUID", "java.util.UUID"), "com.example", Set.of()));
+  }
+
+  @Test
+  void importedFirstSegmentWinsAndDropsTrailingComponents() {
+    // Preserves long-standing ClasspathParser behaviour: `Outer.Inner` where Outer is
+    // imported records only the imported name, not Outer.Inner.
+    assertEquals(
+        Optional.of("com.example.Outer"),
+        TypeNameResolver.resolve(
+            "Outer.Inner", Map.of("Outer", "com.example.Outer"), "pkg", Set.of()));
+  }
+
+  @Test
+  void alreadyDottedNameWithoutImportPassesThrough() {
+    assertEquals(
+        Optional.of("com.example.Foo"),
+        TypeNameResolver.resolve("com.example.Foo", Map.of(), "pkg", Set.of()));
+  }
+
+  @Test
+  void bareNameFallsBackToCurrentPackage() {
+    assertEquals(
+        Optional.of("com.example.Helper"),
+        TypeNameResolver.resolve("Helper", Map.of(), "com.example", Set.of()));
+  }
+
+  @Test
+  void excludedNameSuppressesSamePackageFallback() {
+    assertEquals(
+        Optional.empty(),
+        TypeNameResolver.resolve("String", Map.of(), "com.example", Set.of("String")));
+  }
+
+  @Test
+  void nullCurrentPackageDisablesFallback() {
+    assertEquals(
+        Optional.empty(), TypeNameResolver.resolve("Helper", Map.of(), null, Set.of()));
+  }
+
+  @Test
+  void emptyCurrentPackageDisablesFallback() {
+    assertEquals(Optional.empty(), TypeNameResolver.resolve("Helper", Map.of(), "", Set.of()));
+  }
+
+  @Test
+  void emptyTypeNameReturnsEmpty() {
+    assertEquals(Optional.empty(), TypeNameResolver.resolve("", Map.of(), "pkg", Set.of()));
+  }
+
+  @Test
+  void importTakesPrecedenceOverExclusion() {
+    // If a name is imported, the import wins regardless of exclusions — exclusions only
+    // gate the same-package fallback, not import resolution.
+    assertEquals(
+        Optional.of("java.util.UUID"),
+        TypeNameResolver.resolve(
+            "UUID", Map.of("UUID", "java.util.UUID"), "pkg", Set.of("UUID")));
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/BareClassMethodReceiver.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/BareClassMethodReceiver.java
@@ -1,0 +1,13 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+// No import — SamePackageHelper is a same-package class used as a bare method receiver.
+// visitMethodInvocation only handles MemberSelectTree receivers (a.B.method()),
+// not IdentifierTree receivers (B.method()). So SamePackageHelper.create()
+// is invisible to the method-invocation detection path, and without an import,
+// the same-package fallback in checkFullyQualifiedType is never reached.
+
+public class BareClassMethodReceiver {
+    public void doWork() {
+        SamePackageHelper.create();
+    }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/ClassLiteral.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/ClassLiteral.java
@@ -1,0 +1,10 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+import com.example.Registry;
+
+public class ClassLiteral {
+    public void register() {
+        // The .class literal on MyHandler should be detected as a same-package type reference.
+        Registry.register(MyHandler.class);
+    }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FqnAnnotationOnFieldAndClass.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/FqnAnnotationOnFieldAndClass.java
@@ -1,0 +1,10 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+// No import for com.example.ClassAnnotation or com.example.FieldAnnotation —
+// they are used fully-qualified directly in the source.
+
+@com.example.ClassAnnotation
+public class FqnAnnotationOnFieldAndClass {
+    @com.example.FieldAnnotation
+    private String myField;
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/StaticImportNestedClass.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/java/javaparser/generators/StaticImportNestedClass.java
@@ -1,0 +1,9 @@
+package workspace.com.gazelle.java.javaparser.generators;
+
+import static com.example.Outer.Inner;
+
+public class StaticImportNestedClass {
+    // Inner should be resolvable as a type because the static import brings it into scope.
+    // Current parser doesn't register static-imported class names in currentFileImports.
+    Inner value;
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/BareClassMethodReceiver.kt
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/BareClassMethodReceiver.kt
@@ -1,0 +1,14 @@
+package workspace.com.gazelle.kotlin.javaparser.generators
+
+// No import — SamePackageHelper is in the same package but may be in a different
+// Bazel target (split package). The KtParser relies entirely on imports for
+// usedTypes; visitSimpleNameExpression sees "SamePackageHelper" and recognises
+// it as a likely class name, but never adds it to usedTypes. Without a
+// same-package fallback (like ClasspathParser's checkFullyQualifiedType),
+// this dependency is invisible.
+
+class BareClassMethodReceiver {
+    fun doWork() {
+        SamePackageHelper.create()
+    }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/FqnAnnotations.kt
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/FqnAnnotations.kt
@@ -1,0 +1,13 @@
+package workspace.com.gazelle.kotlin.javaparser.generators
+
+// No imports — annotations are used fully-qualified.
+// FQN annotations bypass the import handler entirely.
+
+@com.example.annotations.ClassAnnotation
+class FqnAnnotations {
+    @com.example.annotations.FieldAnnotation
+    val myField: String = "hello"
+
+    @com.example.annotations.MethodAnnotation
+    fun myMethod() {}
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/FqnTypePositions.kt
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/FqnTypePositions.kt
@@ -1,0 +1,31 @@
+package workspace.com.gazelle.kotlin.javaparser.generators
+
+// No imports — all types are used fully-qualified in type positions.
+// KtParser's tryGetFullyQualifiedName only calls getReferencedName() on KtUserType,
+// which returns the simple name (last segment). The qualifier chain is never walked,
+// so FQN types in these positions are invisible.
+
+class FqnTypePositions {
+    // FQN as function parameter type
+    fun process(input: com.example.types.InputData): String {
+        return input.toString()
+    }
+
+    // FQN as function return type
+    fun create(): com.example.types.OutputData {
+        throw UnsupportedOperationException()
+    }
+
+    // FQN as property type
+    val config: com.example.config.AppConfig = throw UnsupportedOperationException()
+
+    // FQN in is-check
+    fun check(obj: Any): Boolean {
+        return obj is com.example.types.Marker
+    }
+
+    // FQN in as-cast
+    fun cast(obj: Any): Any {
+        return obj as com.example.types.Castable
+    }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/SamePackageAllPositions.kt
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/SamePackageAllPositions.kt
@@ -1,0 +1,22 @@
+package workspace.com.gazelle.kotlin.javaparser.generators
+
+// No imports — every referenced type is in the same package but potentially in
+// a different Bazel target (split package). The Java parser detects all of these
+// via checkFullyQualifiedType's same-package fallback. The Kotlin parser should
+// match it.
+
+class SamePackageAllPositions : SomeSuperType() {
+    val field: SomeFieldType = throw UnsupportedOperationException()
+
+    fun process(input: SomeParamType): SomeReturnType {
+        return throw UnsupportedOperationException()
+    }
+
+    fun check(obj: Any): Boolean {
+        return obj is SomeMarker
+    }
+
+    fun cast(obj: Any): SomeCastTarget {
+        return obj as SomeCastTarget
+    }
+}


### PR DESCRIPTION
`ClasspathParser` missed FQN annotations on fields/classes, `.class` literals, bare class method receivers, and static imports of nested classes.

`KtParser` missed FQN references in expressions, type positions, and annotations, and had no same-package fallback for bare class method receivers (which matters for split packages).

This change also makes an effort to share type-name resolution between the two parsers. There's a lot of overlap between the two languages, and we don't want to introduce drift where we fix a bug in one parser but not the other.