### PR TITLE
[javaparser] Close StandardJavaFileManager to stop leaking file descriptors

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -166,8 +166,7 @@ public class ClasspathParser {
   @VisibleForTesting
   ParsedPackageData parseClasses(JavaCompiler compiler, Path directory, List<String> files)
       throws IOException {
-    try (StandardJavaFileManager fileManager =
-        compiler.getStandardFileManager(null, null, null)) {
+    try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null)) {
       List<? extends JavaFileObject> objectFiles =
           files.stream()
               .map(directory::resolve)

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -5,6 +5,7 @@ import static javax.lang.model.element.Modifier.PRIVATE;
 import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.sun.source.tree.AnnotationTree;
@@ -159,6 +160,12 @@ public class ClasspathParser {
   }
 
   public ParsedPackageData parseClasses(Path directory, List<String> files) throws IOException {
+    return parseClasses(compiler, directory, files);
+  }
+
+  @VisibleForTesting
+  ParsedPackageData parseClasses(JavaCompiler compiler, Path directory, List<String> files)
+      throws IOException {
     try (StandardJavaFileManager fileManager =
         compiler.getStandardFileManager(null, null, null)) {
       List<? extends JavaFileObject> objectFiles =
@@ -177,16 +184,16 @@ public class ClasspathParser {
         logger.debug("JavaTools: No files given to parse, skipping directory: {}", directory);
         throw new IOException("No files to process");
       }
-      return parseFileGatherDependencies(objectFiles);
+      return parseFileGatherDependencies(compiler, objectFiles);
     }
   }
 
   public ParsedPackageData parseClasses(List<? extends JavaFileObject> files) throws IOException {
-    return parseFileGatherDependencies(files);
+    return parseFileGatherDependencies(compiler, files);
   }
 
   private ParsedPackageData parseFileGatherDependencies(
-      Iterable<? extends JavaFileObject> compUnits) throws IOException {
+      JavaCompiler compiler, Iterable<? extends JavaFileObject> compUnits) throws IOException {
     ParsedPackageData data = new ParsedPackageData();
     JavacTask task = (JavacTask) compiler.getTask(null, null, null, OPTIONS, null, compUnits);
     try {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParser.java
@@ -159,24 +159,26 @@ public class ClasspathParser {
   }
 
   public ParsedPackageData parseClasses(Path directory, List<String> files) throws IOException {
-    StandardJavaFileManager fileManager = compiler.getStandardFileManager(null, null, null);
-    List<? extends JavaFileObject> objectFiles =
-        files.stream()
-            .map(directory::resolve)
-            .map(fileName -> fileManager.getJavaFileObjects(fileName.toString()))
-            .map(Lists::newArrayList)
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
-    // This happens when Gazelle is run in module mode, it wants to process the module level
-    // directory, which would not
-    // have any files. This is not an error, and should just be skipped. The IOException is caught
-    // the next level up,
-    // logged, and ignored.
-    if (objectFiles.isEmpty()) {
-      logger.debug("JavaTools: No files given to parse, skipping directory: {}", directory);
-      throw new IOException("No files to process");
+    try (StandardJavaFileManager fileManager =
+        compiler.getStandardFileManager(null, null, null)) {
+      List<? extends JavaFileObject> objectFiles =
+          files.stream()
+              .map(directory::resolve)
+              .map(fileName -> fileManager.getJavaFileObjects(fileName.toString()))
+              .map(Lists::newArrayList)
+              .flatMap(List::stream)
+              .collect(Collectors.toList());
+      // This happens when Gazelle is run in module mode, it wants to process the module level
+      // directory, which would not
+      // have any files. This is not an error, and should just be skipped. The IOException is caught
+      // the next level up,
+      // logged, and ignored.
+      if (objectFiles.isEmpty()) {
+        logger.debug("JavaTools: No files given to parse, skipping directory: {}", directory);
+        throw new IOException("No files to process");
+      }
+      return parseFileGatherDependencies(objectFiles);
     }
-    return parseFileGatherDependencies(objectFiles);
   }
 
   public ParsedPackageData parseClasses(List<? extends JavaFileObject> files) throws IOException {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/BUILD.bazel
@@ -33,6 +33,7 @@ java_test_suite(
         "@contrib_rules_jvm_deps//:junit_junit",
         "@contrib_rules_jvm_deps//:org_junit_jupiter_junit_jupiter_api",
         "@contrib_rules_jvm_deps//:org_slf4j_slf4j_api",
+        "@contrib_rules_jvm_tests//:org_mockito_mockito_core",
     ],
 )
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
@@ -23,9 +25,11 @@ import java.util.stream.Stream;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -510,6 +514,45 @@ public class ClasspathParserTest {
     // Should contain the nested class FQN from the static import, not a
     // same-package fallback like workspace.com.gazelle...Inner
     assertEquals(Set.of("com.example.Outer", "com.example.Outer.Inner"), data.usedTypes);
+  }
+
+  @Test
+  public void parseClassesByPath(@TempDir Path tempDir) throws IOException {
+    Path src = tempDir.resolve("Greeter.java");
+    Files.writeString(src, "package demo; public class Greeter {}");
+
+    ParsedPackageData data = parser.parseClasses(tempDir, List.of("Greeter.java"));
+
+    assertEquals(Set.of("demo"), data.packages);
+  }
+
+  @Test
+  public void parseClassesByPathDoesNotLeakFileDescriptors(@TempDir Path tempDir)
+      throws IOException {
+    OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+    Assumptions.assumeTrue(
+        osBean instanceof com.sun.management.UnixOperatingSystemMXBean,
+        "FD-count probe only available on Unix-like JVMs");
+    com.sun.management.UnixOperatingSystemMXBean unix =
+        (com.sun.management.UnixOperatingSystemMXBean) osBean;
+
+    Path src = tempDir.resolve("Greeter.java");
+    Files.writeString(src, "package demo; public class Greeter {}");
+
+    // Warm up so any one-time native allocations don't pollute the delta.
+    for (int i = 0; i < 10; i++) {
+      parser.parseClasses(tempDir, List.of("Greeter.java"));
+    }
+    long before = unix.getOpenFileDescriptorCount();
+    for (int i = 0; i < 500; i++) {
+      parser.parseClasses(tempDir, List.of("Greeter.java"));
+    }
+    long after = unix.getOpenFileDescriptorCount();
+
+    // Before the try-with-resources fix, the delta grew by ~1 FD per call.
+    Assertions.assertTrue(
+        after - before < 50,
+        String.format("open FD count grew unexpectedly: before=%d after=%d", before, after));
   }
 
   private <T> TreeSet<T> treeSet(T... values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -2,10 +2,15 @@ package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
-import java.lang.management.ManagementFactory;
-import java.lang.management.OperatingSystemMXBean;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystems;
@@ -22,10 +27,12 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -527,32 +534,32 @@ public class ClasspathParserTest {
   }
 
   @Test
-  public void parseClassesByPathDoesNotLeakFileDescriptors(@TempDir Path tempDir)
-      throws IOException {
-    OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
-    Assumptions.assumeTrue(
-        osBean instanceof com.sun.management.UnixOperatingSystemMXBean,
-        "FD-count probe only available on Unix-like JVMs");
-    com.sun.management.UnixOperatingSystemMXBean unix =
-        (com.sun.management.UnixOperatingSystemMXBean) osBean;
-
+  public void parseClassesByPathClosesFileManager(@TempDir Path tempDir) throws IOException {
     Path src = tempDir.resolve("Greeter.java");
     Files.writeString(src, "package demo; public class Greeter {}");
 
-    // Warm up so any one-time native allocations don't pollute the delta.
-    for (int i = 0; i < 10; i++) {
-      parser.parseClasses(tempDir, List.of("Greeter.java"));
-    }
-    long before = unix.getOpenFileDescriptorCount();
-    for (int i = 0; i < 500; i++) {
-      parser.parseClasses(tempDir, List.of("Greeter.java"));
-    }
-    long after = unix.getOpenFileDescriptorCount();
+    JavaCompiler realCompiler = ToolProvider.getSystemJavaCompiler();
+    StandardJavaFileManager realFm = realCompiler.getStandardFileManager(null, null, null);
+    // delegatesTo gives us a recording proxy that forwards every call to realFm — unlike spy(),
+    // which fails on JavacFileManager because of its internal init state.
+    StandardJavaFileManager observableFm =
+        mock(StandardJavaFileManager.class, withSettings().defaultAnswer(delegatesTo(realFm)));
+    JavaCompiler mockCompiler = mock(JavaCompiler.class);
+    when(mockCompiler.getStandardFileManager(any(), any(), any())).thenReturn(observableFm);
+    when(mockCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenAnswer(
+            inv ->
+                realCompiler.getTask(
+                    inv.getArgument(0),
+                    inv.getArgument(1),
+                    inv.getArgument(2),
+                    inv.getArgument(3),
+                    inv.getArgument(4),
+                    inv.getArgument(5)));
 
-    // Before the try-with-resources fix, the delta grew by ~1 FD per call.
-    Assertions.assertTrue(
-        after - before < 50,
-        String.format("open FD count grew unexpectedly: before=%d after=%d", before, after));
+    parser.parseClasses(mockCompiler, tempDir, List.of("Greeter.java"));
+
+    verify(observableFm).close();
   }
 
   private <T> TreeSet<T> treeSet(T... values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -1,7 +1,6 @@
 package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -539,27 +538,31 @@ public class ClasspathParserTest {
     Files.writeString(src, "package demo; public class Greeter {}");
 
     JavaCompiler realCompiler = ToolProvider.getSystemJavaCompiler();
-    StandardJavaFileManager realFm = realCompiler.getStandardFileManager(null, null, null);
     // delegatesTo gives us a recording proxy that forwards every call to realFm — unlike spy(),
-    // which fails on JavacFileManager because of its internal init state.
-    StandardJavaFileManager observableFm =
-        mock(StandardJavaFileManager.class, withSettings().defaultAnswer(delegatesTo(realFm)));
-    JavaCompiler mockCompiler = mock(JavaCompiler.class);
-    when(mockCompiler.getStandardFileManager(any(), any(), any())).thenReturn(observableFm);
-    when(mockCompiler.getTask(any(), any(), any(), any(), any(), any()))
-        .thenAnswer(
-            inv ->
-                realCompiler.getTask(
-                    inv.getArgument(0),
-                    inv.getArgument(1),
-                    inv.getArgument(2),
-                    inv.getArgument(3),
-                    inv.getArgument(4),
-                    inv.getArgument(5)));
+    // which fails on JavacFileManager because of its internal init state. realFm and observableFm
+    // are both put in try-with-resources so PMD is satisfied; close() is idempotent so the extra
+    // call from this test on top of the production call we're verifying is harmless.
+    try (StandardJavaFileManager realFm = realCompiler.getStandardFileManager(null, null, null);
+        StandardJavaFileManager observableFm =
+            mock(
+                StandardJavaFileManager.class, withSettings().defaultAnswer(delegatesTo(realFm)))) {
+      JavaCompiler mockCompiler = mock(JavaCompiler.class);
+      when(mockCompiler.getStandardFileManager(any(), any(), any())).thenReturn(observableFm);
+      when(mockCompiler.getTask(any(), any(), any(), any(), any(), any()))
+          .thenAnswer(
+              inv ->
+                  realCompiler.getTask(
+                      inv.getArgument(0),
+                      inv.getArgument(1),
+                      inv.getArgument(2),
+                      inv.getArgument(3),
+                      inv.getArgument(4),
+                      inv.getArgument(5)));
 
-    parser.parseClasses(mockCompiler, tempDir, List.of("Greeter.java"));
+      parser.parseClasses(mockCompiler, tempDir, List.of("Greeter.java"));
 
-    verify(observableFm).close();
+      verify(observableFm).close();
+    }
   }
 
   private <T> TreeSet<T> treeSet(T... values) {

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/ClasspathParserTest.java
@@ -538,14 +538,13 @@ public class ClasspathParserTest {
     Files.writeString(src, "package demo; public class Greeter {}");
 
     JavaCompiler realCompiler = ToolProvider.getSystemJavaCompiler();
-    // delegatesTo gives us a recording proxy that forwards every call to realFm — unlike spy(),
-    // which fails on JavacFileManager because of its internal init state. realFm and observableFm
-    // are both put in try-with-resources so PMD is satisfied; close() is idempotent so the extra
-    // call from this test on top of the production call we're verifying is harmless.
-    try (StandardJavaFileManager realFm = realCompiler.getStandardFileManager(null, null, null);
-        StandardJavaFileManager observableFm =
-            mock(
-                StandardJavaFileManager.class, withSettings().defaultAnswer(delegatesTo(realFm)))) {
+    try (StandardJavaFileManager realFm = realCompiler.getStandardFileManager(null, null, null)) {
+      // delegatesTo gives us a recording proxy that forwards every call to realFm — unlike spy(),
+      // which fails on JavacFileManager because of its internal init state. We deliberately don't
+      // close observableFm from here: its close() call is what this test is asserting.
+      @SuppressWarnings("PMD.CloseResource")
+      StandardJavaFileManager observableFm =
+          mock(StandardJavaFileManager.class, withSettings().defaultAnswer(delegatesTo(realFm)));
       JavaCompiler mockCompiler = mock(JavaCompiler.class);
       when(mockCompiler.getStandardFileManager(any(), any(), any())).thenReturn(observableFm);
       when(mockCompiler.getTask(any(), any(), any(), any(), any(), any()))


### PR DESCRIPTION
## Summary
- `ClasspathParser.parseClasses(Path, List<String>)` constructs a `StandardJavaFileManager` and never closes it. Each call leaks both the native file-manager handle and the FDs of the `JavaFileObject`s it produces.
- Long-lived JVMs (e.g. the persistent javaparser gRPC server) can exhaust the per-process FD limit after enough invocations.
- Fix: wrap the manager in try-with-resources.
