### PR TITLE
[gazelle] Kotlin import-resolution fixes

### DIFF
--- a/java/gazelle/private/kotlin/kotlin.go
+++ b/java/gazelle/private/kotlin/kotlin.go
@@ -6,6 +6,14 @@ import (
 
 var kotlinStdLibPrefix = types.NewPackageName("kotlin")
 
+// kotlinTestPrefix is in the `kotlin` namespace but ships in a separate artifact
+// (org.jetbrains.kotlin:kotlin-test), not kotlin-stdlib, so it must resolve to a maven
+// dependency rather than being assumed on the classpath.
+var kotlinTestPrefix = types.NewPackageName("kotlin.test")
+
 func IsStdlib(imp types.PackageName) bool {
+	if types.PackageNamesHasPrefix(imp, kotlinTestPrefix) {
+		return false
+	}
 	return types.PackageNamesHasPrefix(imp, kotlinStdLibPrefix)
 }

--- a/java/gazelle/private/kotlin/kotlin_test.go
+++ b/java/gazelle/private/kotlin/kotlin_test.go
@@ -14,6 +14,12 @@ func TestIsStdLib(t *testing.T) {
 		"kotlin.collections": true,
 		"java.lang":          false,
 		"com.example":        false,
+		// kotlin.test ships as a separate artifact, so it is not stdlib.
+		"kotlin.test":       false,
+		"kotlin.test.junit": false,
+		// kotlin.testing is a distinct package that still lives under kotlin, so the
+		// kotlin.test exclusion must not match it on a bare string prefix.
+		"kotlin.testing": true,
 	}
 
 	for pkg, want := range tests {

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -236,9 +236,12 @@ public class KtParser {
       }
       if (foundClass) {
         FqName className = importName;
-        if (!isLikelyClassName(importName.shortName().asString())) {
-          // If we're directly importing a function from a parent class or object, use the parent.
-          className = importName.parent();
+        // Walk up to the outermost class-like segment. A deeply nested member import
+        // (e.g. clientsync/ktranslate StringResources.foo.bar.baz) names a member nested
+        // under a class, so the resolvable type is the longest prefix ending in a class
+        // segment -- not just the immediate parent, which would leave a phantom package.
+        while (!className.isRoot() && !isLikelyClassName(className.shortName().asString())) {
+          className = className.parent();
         }
         String localName = importDirective.getAliasName();
         if (localName == null) {


### PR DESCRIPTION
Two small, independent Kotlin import-resolution fixes.

- Deeply-nested member imports (e.g. `StringResources.a.b.c`) were mapped only to their immediate parent, leaving a phantom package that never resolves. Walk up to the outermost class-like segment so the longest class-rooted prefix becomes the resolvable type.
- `kotlin.test` is in the `kotlin` namespace but ships as a separate artifact (`org.jetbrains.kotlin:kotlin-test`), not `kotlin-stdlib`. Exclude it from the stdlib check so it resolves to a Maven dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)