### PR TITLE
[gazelle] Guard FQN receiver detection against arbitrary call chains

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParser.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.jetbrains.kotlin.cli.jvm.compiler.EnvironmentConfigFiles;
 import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment;
@@ -59,6 +60,11 @@ import org.slf4j.LoggerFactory;
 
 public class KtParser {
   private static final Logger logger = LoggerFactory.getLogger(GrpcServer.class);
+
+  // Matches a dotted identifier chain -- letters/digits/underscores only. Rejects any receiver
+  // text with parentheses (a call chain) so we don't record `foo(x).bar(y).Baz` as an FQN.
+  private static final Pattern QUALIFIED_NAME =
+      Pattern.compile("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+");
 
   private final CompilerConfiguration compilerConf = createCompilerConfiguration();
   private final KotlinCoreEnvironment env =
@@ -627,8 +633,9 @@ public class KtParser {
 
           // FQN constructor / static call: com.example.ClassName(args) or
           // com.example.ClassName.fn() — when the call's name is a class-like
-          // identifier and the receiver chain has dots, record the full qualified type.
-          if (isLikelyClassName(functionName) && receiverExpression.getText().contains(".")) {
+          // identifier and the receiver is a dotted identifier chain (not an arbitrary
+          // call chain like `foo(x).bar(y)`), record the full qualified type.
+          if (isLikelyClassName(functionName) && isQualifiedName(receiverExpression.getText())) {
             packageData.usedTypes.add(receiverExpression.getText() + "." + functionName);
           }
         }
@@ -645,7 +652,7 @@ public class KtParser {
         String selectorName = ((KtSimpleNameExpression) selectorExpression).getReferencedName();
         if (isLikelyClassName(selectorName)
             && receiverExpression != null
-            && receiverExpression.getText().contains(".")) {
+            && isQualifiedName(receiverExpression.getText())) {
           packageData.usedTypes.add(receiverExpression.getText() + "." + selectorName);
         }
       }
@@ -736,6 +743,10 @@ public class KtParser {
                 + resolvedType
                 + " will use componentN() dependencies already captured");
       }
+    }
+
+    private boolean isQualifiedName(String text) {
+      return QUALIFIED_NAME.matcher(text).matches();
     }
 
     /**

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/KtParserTest.java
@@ -1,6 +1,7 @@
 package com.github.bazel_contrib.contrib_rules_jvm.javaparser.generators;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -175,6 +176,20 @@ public class KtParserTest {
     assertTrue(
         data.usedTypes.contains("java.util.ArrayList"),
         "Should detect FQN constructor call for ArrayList. Found: " + data.usedTypes);
+  }
+
+  @Test
+  public void testCallChainWithClassLikeSelectorNotTreatedAsFqn() throws IOException {
+    // A Kotlin call chain like `Value.foo(1).Bar()` has a receiver whose text
+    // contains a `.` but is not a fully-qualified identifier (it has parens).
+    // The class-like final selector must not cause the chain to be recorded as a
+    // fully-qualified class reference.
+    ParsedPackageData data = parser.parseClasses(getPathsWithNames("CallChainReceivers.kt"));
+
+    assertFalse(
+        data.usedTypes.contains("Value.foo(1).Bar"),
+        "Call-chain receivers with parens must not be treated as FQN class references. Found: "
+            + data.usedTypes);
   }
 
   @Test

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/CallChainReceivers.kt
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/javaparser/generators/workspace/com/gazelle/kotlin/javaparser/generators/CallChainReceivers.kt
@@ -1,0 +1,10 @@
+package workspace.com.gazelle.kotlin.javaparser.generators
+
+class CallChainReceivers {
+  fun demo() {
+    // Call chain: the receiver of the final `.Bar()` selector is `Value.foo(1)`,
+    // whose text contains a `.` but is not a fully-qualified identifier (parens).
+    // Must not be recorded as a class reference.
+    Value.foo(1).Bar()
+  }
+}


### PR DESCRIPTION
`#453` introduced `isLikelyClassName` and detects FQN static calls like `com.example.Foo.bar()` by combining that check with `receiver.getText().contains(".")`. Any receiver text with a `.` in it is treated as class-like, so a Kotlin call chain such as `foo(x).bar(y).Baz()` — receiver `foo(x).bar(y)` contains a `.` — ends up recorded as an FQN class reference (`foo(x).bar(y).Baz`). The dependency resolver then tries and fails to resolve that phantom type.

Guard both FQN paths (KtCallExpression and KtSimpleNameExpression selectors) with a stricter regex that only matches dotted alphanumeric identifiers, so receivers containing parentheses are rejected. Legitimate FQN calls (`com.example.Foo.bar()`, `java.util.ArrayList()`) still match.

Draft while I gather any additional cases we want covered before marking ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)