### PR TITLE
Add opt-in invocation-level sharding for parameterized tests

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/README.md
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/README.md
@@ -18,6 +18,50 @@ tag. This can contain any number of `testsuite` tags. Each of these
 `testsuite` tags may only contain any number of nested `testcase` tags. The 
 model does not allow nesting of `testsuite` tags within `testsuite` tags. 
 
+## Test sharding
+
+The runner supports [Bazel test sharding][sharding] via a `PostDiscoveryFilter`
+which assigns each test to a shard based on a hash of its unique ID. Because
+post-discovery filters run before test templates (such as `@ParameterizedTest`
+or `@RepeatedTest` methods) have generated their invocations, a test template
+is assigned to a shard as a single unit by default: all of its invocations run
+on the same shard.
+
+### Sharding the invocations of a test template
+
+If a single parameterized or repeated test dominates the runtime of a shard,
+you can opt in to distributing its invocations across shards by annotating the
+test method (or its class, to opt in every test template in the class) with
+`@ShardTemplateInvocations`:
+
+```java
+@ShardTemplateInvocations
+@ParameterizedTest
+@ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+void myTest(int value) {
+  // ...
+}
+```
+
+The test template is then included on every shard, and each invocation is
+enabled on exactly one shard: invocation `N` (1-based) runs on shard
+`(N - 1) % TEST_TOTAL_SHARDS`, which is deterministic and keeps per-shard
+invocation counts balanced. Invocations belonging to other shards are reported
+as skipped in that shard's XML output.
+
+Note that:
+
+* The set and order of invocations must be stable across shards: every shard
+  must generate the same invocations in the same order, so argument providers
+  must be deterministic. If they are not, some invocations may run on more
+  than one shard or on no shard at all.
+* `@TestFactory` methods are not supported: dynamic tests cannot be
+  conditionally disabled, so test factories are always sharded as a single
+  unit.
+* The annotation has no effect when test sharding is not enabled.
+
+[sharding]: https://bazel.build/reference/test-encyclopedia#test-sharding
+
 ## Test log formats
 
 JUnit5 has a number of different ways of running and not running tests, so a 

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ShardTemplateInvocations.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/ShardTemplateInvocations.java
@@ -1,0 +1,36 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Opt-in annotation that distributes the individual invocations of a JUnit Jupiter test template
+ * (for example {@code @ParameterizedTest} or {@code @RepeatedTest}) across Bazel test shards.
+ *
+ * <p>By default the shard filter treats a test template as a single unit, because the invocations
+ * of a template do not exist at discovery time, which is when the filter runs. As a result, all
+ * invocations of a parameterized or repeated test run on the same shard. Annotating the template
+ * method (or its class, to opt in every template in the class) instead includes the template on
+ * every shard and enables each invocation on exactly one shard: invocation {@code N} (1-based) is
+ * assigned round-robin to shard {@code (N - 1) % TEST_TOTAL_SHARDS}, which is deterministic and
+ * keeps per-shard invocation counts balanced. Invocations assigned to other shards are reported as
+ * skipped on the current shard.
+ *
+ * <p>This requires the set and order of invocations to be stable across shards: every shard must
+ * generate the same invocations in the same order, so argument providers must be deterministic. If
+ * they are not, some invocations may run on multiple shards or not at all.
+ *
+ * <p>This annotation is not supported on {@code @TestFactory} methods: dynamic tests cannot be
+ * conditionally disabled, so test factories continue to be sharded as a single unit.
+ *
+ * <p>Has no effect when test sharding is not enabled.
+ */
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(TemplateInvocationShardingCondition.class)
+public @interface ShardTemplateInvocations {}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TemplateInvocationShardingCondition.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TemplateInvocationShardingCondition.java
@@ -1,0 +1,55 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.platform.engine.UniqueId;
+
+/**
+ * An {@link ExecutionCondition} which enables each invocation of a test template (such as a
+ * {@code @ParameterizedTest} or {@code @RepeatedTest}) on exactly one Bazel test shard.
+ *
+ * <p>This condition is registered by annotating a test template method (or its class) with {@link
+ * ShardTemplateInvocations}. It cooperates with the {@code PostDiscoveryFilter} created by {@link
+ * TestSharding#makeShardFilter()}: the filter includes annotated test templates on every shard
+ * (rather than hashing them onto a single shard), and this condition then enables each invocation
+ * on exactly one shard, assigning invocation {@code N} (1-based) round-robin to shard {@code (N -
+ * 1) % TEST_TOTAL_SHARDS}.
+ */
+public class TemplateInvocationShardingCondition implements ExecutionCondition {
+
+  private static final String TEST_TEMPLATE_INVOCATION_SEGMENT_TYPE = "test-template-invocation";
+
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    if (!TestSharding.isShardingEnabled()) {
+      return ConditionEvaluationResult.enabled("test sharding is disabled");
+    }
+
+    UniqueId.Segment lastSegment = UniqueId.parse(context.getUniqueId()).getLastSegment();
+    if (!TEST_TEMPLATE_INVOCATION_SEGMENT_TYPE.equals(lastSegment.getType())) {
+      // Containers (the test class, the test template itself, ...) must always be enabled: the
+      // per-invocation decision is made when each invocation's own context is evaluated.
+      return ConditionEvaluationResult.enabled("not a test template invocation");
+    }
+
+    int invocation;
+    try {
+      // The segment value has the form "#N" where N is the 1-based invocation index.
+      invocation = Integer.parseInt(lastSegment.getValue().substring(1));
+    } catch (RuntimeException e) {
+      // If the invocation index cannot be determined, prefer running the invocation on every
+      // shard (duplicated work) over silently dropping it from all shards.
+      return ConditionEvaluationResult.enabled(
+          "unable to parse test template invocation index from segment value '"
+              + lastSegment.getValue()
+              + "'");
+    }
+
+    if (Math.floorMod(invocation - 1, TestSharding.getTotalShards())
+        == TestSharding.getShardIndex()) {
+      return ConditionEvaluationResult.enabled("test template invocation is in current shard");
+    }
+    return ConditionEvaluationResult.disabled("test template invocation is in different shard");
+  }
+}

--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSharding.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSharding.java
@@ -7,7 +7,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileTime;
+import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.engine.FilterResult;
+import org.junit.platform.engine.TestDescriptor;
+import org.junit.platform.engine.TestSource;
+import org.junit.platform.engine.support.descriptor.MethodSource;
 import org.junit.platform.launcher.PostDiscoveryFilter;
 
 final class TestSharding {
@@ -31,6 +35,18 @@ final class TestSharding {
         return FilterResult.included("non-test nodes in the test plan are always included");
       }
 
+      // Test templates which have opted in to invocation-level sharding are included on every
+      // shard: TemplateInvocationShardingCondition then enables each of their invocations on
+      // exactly one shard at execution time. This deliberately only applies to test templates
+      // (@ParameterizedTest, @RepeatedTest, ...), never to test factories: dynamic tests cannot
+      // be conditionally disabled, so including a factory on every shard would run its tests on
+      // every shard.
+      if (testDescriptor.mayRegisterTests()
+          && isTestTemplate(testDescriptor)
+          && isAnnotatedForInvocationSharding(testDescriptor)) {
+        return FilterResult.included("test template invocations are sharded individually");
+      }
+
       // A JUnit test plan has a tree structure with potentially multiple roots that can change at
       // execution time due to dynamic tests. Rather than enumerating all tests and assigning them
       // to shards, use a hash of the test ID.
@@ -46,15 +62,49 @@ final class TestSharding {
     };
   }
 
-  private static boolean isShardingEnabled() {
+  private static boolean isTestTemplate(TestDescriptor testDescriptor) {
+    return "test-template".equals(testDescriptor.getUniqueId().getLastSegment().getType());
+  }
+
+  private static boolean isAnnotatedForInvocationSharding(TestDescriptor testDescriptor) {
+    try {
+      TestSource source = testDescriptor.getSource().orElse(null);
+      if (!(source instanceof MethodSource)) {
+        return false;
+      }
+      MethodSource methodSource = (MethodSource) source;
+      if (AnnotationSupport.findAnnotation(
+              methodSource.getJavaMethod(), ShardTemplateInvocations.class)
+          .isPresent()) {
+        return true;
+      }
+      // Also honour the annotation when present on the test class, one of its superclasses or
+      // interfaces (handled by AnnotationSupport), or an enclosing class (for @Nested classes,
+      // which inherit class-level extensions from their enclosing classes).
+      for (Class<?> clazz = methodSource.getJavaClass();
+          clazz != null;
+          clazz = clazz.getEnclosingClass()) {
+        if (AnnotationSupport.findAnnotation(clazz, ShardTemplateInvocations.class).isPresent()) {
+          return true;
+        }
+      }
+      return false;
+    } catch (RuntimeException e) {
+      // If we cannot determine whether the test template opted in (for example because the test
+      // class could not be loaded), fall back to sharding the whole template as a single unit.
+      return false;
+    }
+  }
+
+  static boolean isShardingEnabled() {
     return System.getenv("TEST_TOTAL_SHARDS") != null;
   }
 
-  private static long getShardIndex() {
+  static long getShardIndex() {
     return Integer.parseUnsignedInt(System.getenv().getOrDefault("TEST_SHARD_INDEX", "0"));
   }
 
-  private static long getTotalShards() {
+  static long getTotalShards() {
     return Integer.parseUnsignedInt(System.getenv().getOrDefault("TEST_TOTAL_SHARDS", "1"));
   }
 

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/BUILD.bazel
@@ -5,6 +5,11 @@ load("//java:defs.bzl", "java_junit5_test", "java_test_suite", "junit5_deps", "j
 # Ignore this directory because of the wrong package name.
 # gazelle:ignore
 
+INVOCATION_SHARDING_TESTS = [
+    "InvocationShardingTest.java",
+    "InvocationShardingUnshardedTest.java",
+]
+
 PACKAGE_NAME_TEST = [
     "WrongPackageNameTest.java",
 ]
@@ -26,7 +31,7 @@ java_test_suite(
     size = "small",
     srcs = glob(
         ["*.java"],
-        exclude = PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST + VINTAGE_NESTED_TEST,
+        exclude = INVOCATION_SHARDING_TESTS + PACKAGE_NAME_TEST + PARALLEL_TEST + SHARDING_TEST + VINTAGE_NESTED_TEST,
     ),
     exclude_engines = ["junit-vintage"],
     include_engines = ["junit-jupiter"],
@@ -84,6 +89,36 @@ java_test(
     deps = [
         "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
         "//java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample:sharding-test-tests",
+        artifact("junit:junit", "contrib_rules_jvm_tests"),
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+        artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+# Use a Bazel test runner with a known good test sharding implementation.
+java_test(
+    name = "invocation-sharding-test",
+    size = "small",
+    srcs = ["InvocationShardingTest.java"],
+    shard_count = 3,
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.InvocationShardingTest",
+    deps = [
+        "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
+        "//java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample:invocation-sharding-test-tests",
+        artifact("junit:junit", "contrib_rules_jvm_tests"),
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+        artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)
+
+java_test(
+    name = "invocation-sharding-unsharded-test",
+    size = "small",
+    srcs = ["InvocationShardingUnshardedTest.java"],
+    test_class = "com.github.bazel_contrib.contrib_rules_jvm.junit5.InvocationShardingUnshardedTest",
+    deps = [
+        "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
+        "//java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample:invocation-sharding-test-tests",
         artifact("junit:junit", "contrib_rules_jvm_tests"),
         artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
         artifact("org.junit.platform:junit-platform-engine", "contrib_rules_jvm_tests"),

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/InvocationShardingTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/InvocationShardingTest.java
@@ -1,0 +1,171 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.bazel_contrib.contrib_rules_jvm.junit5.sample.ShardingAnnotatedTests;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+/**
+ * Tests invocation-level sharding of test templates annotated with {@link
+ * ShardTemplateInvocations}.
+ *
+ * <p>Runs via a Bazel test runner with a known good test sharding implementation and {@code
+ * shard_count = 3}, which deterministically runs {@code testShardN} on shard {@code N - 1} (each
+ * test method asserts this). Each test method then runs the JUnit Platform launcher in-process with
+ * the shard filter installed and asserts exactly which tests were started and which test template
+ * invocations were skipped on the current shard:
+ *
+ * <ul>
+ *   <li>Annotated test templates are started on every shard, with started invocations being exactly
+ *       the round-robin slice for the shard (invocation N runs on shard (N - 1) % 3) and all other
+ *       invocations reported as skipped.
+ *   <li>The non-annotated test template keeps the existing behaviour: it is hash-assigned to a
+ *       single shard (shard 2 for this test class), where all of its invocations run.
+ * </ul>
+ */
+public class InvocationShardingTest {
+
+  private static final UniqueId ENGINE_ID = UniqueId.forEngine("junit-jupiter");
+  private static final UniqueId TEST_CLASS =
+      ENGINE_ID.append("class", ShardingAnnotatedTests.class.getName());
+  private static final UniqueId SHARDED_PARAMETERIZED =
+      TEST_CLASS.append("test-template", "testShardedParameterized(int)");
+  private static final UniqueId SHARDED_REPEATED =
+      TEST_CLASS.append("test-template", "testShardedRepeated()");
+  private static final UniqueId UNSHARDED_PARAMETERIZED =
+      TEST_CLASS.append("test-template", "testUnshardedParameterized(int)");
+
+  private Set<UniqueId> started;
+  private Set<UniqueId> skipped;
+
+  @Before
+  public void setUp() {
+    LauncherDiscoveryRequest request =
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(DiscoverySelectors.selectClass(ShardingAnnotatedTests.class))
+            .build();
+
+    started = new HashSet<>();
+    skipped = new HashSet<>();
+    PostDiscoveryFilter shardFilter = TestSharding.makeShardFilter();
+    LauncherConfig config =
+        LauncherConfig.builder()
+            .addTestExecutionListeners(
+                new TestExecutionListener() {
+                  @Override
+                  public void executionStarted(TestIdentifier testIdentifier) {
+                    started.add(testIdentifier.getUniqueIdObject());
+                  }
+
+                  @Override
+                  public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+                    skipped.add(testIdentifier.getUniqueIdObject());
+                  }
+                })
+            .addPostDiscoveryFilters(shardFilter)
+            .build();
+
+    LauncherFactory.create(config).execute(request);
+  }
+
+  @Test
+  public void testShard1() {
+    assertEquals("0", System.getenv("TEST_SHARD_INDEX"));
+    assertEquals(
+        Set.of(
+            ENGINE_ID,
+            TEST_CLASS,
+            SHARDED_PARAMETERIZED,
+            invocation(SHARDED_PARAMETERIZED, 1),
+            invocation(SHARDED_PARAMETERIZED, 4),
+            invocation(SHARDED_PARAMETERIZED, 7),
+            SHARDED_REPEATED,
+            invocation(SHARDED_REPEATED, 1),
+            invocation(SHARDED_REPEATED, 4)),
+        started);
+    assertEquals(
+        Set.of(
+            invocation(SHARDED_PARAMETERIZED, 2),
+            invocation(SHARDED_PARAMETERIZED, 3),
+            invocation(SHARDED_PARAMETERIZED, 5),
+            invocation(SHARDED_PARAMETERIZED, 6),
+            invocation(SHARDED_REPEATED, 2),
+            invocation(SHARDED_REPEATED, 3),
+            invocation(SHARDED_REPEATED, 5)),
+        skipped);
+  }
+
+  @Test
+  public void testShard2() {
+    assertEquals("1", System.getenv("TEST_SHARD_INDEX"));
+    assertEquals(
+        Set.of(
+            ENGINE_ID,
+            TEST_CLASS,
+            SHARDED_PARAMETERIZED,
+            invocation(SHARDED_PARAMETERIZED, 2),
+            invocation(SHARDED_PARAMETERIZED, 5),
+            SHARDED_REPEATED,
+            invocation(SHARDED_REPEATED, 2),
+            invocation(SHARDED_REPEATED, 5)),
+        started);
+    assertEquals(
+        Set.of(
+            invocation(SHARDED_PARAMETERIZED, 1),
+            invocation(SHARDED_PARAMETERIZED, 3),
+            invocation(SHARDED_PARAMETERIZED, 4),
+            invocation(SHARDED_PARAMETERIZED, 6),
+            invocation(SHARDED_PARAMETERIZED, 7),
+            invocation(SHARDED_REPEATED, 1),
+            invocation(SHARDED_REPEATED, 3),
+            invocation(SHARDED_REPEATED, 4)),
+        skipped);
+  }
+
+  @Test
+  public void testShard3() {
+    assertEquals("2", System.getenv("TEST_SHARD_INDEX"));
+    assertEquals(
+        Set.of(
+            ENGINE_ID,
+            TEST_CLASS,
+            SHARDED_PARAMETERIZED,
+            invocation(SHARDED_PARAMETERIZED, 3),
+            invocation(SHARDED_PARAMETERIZED, 6),
+            SHARDED_REPEATED,
+            invocation(SHARDED_REPEATED, 3),
+            UNSHARDED_PARAMETERIZED,
+            invocation(UNSHARDED_PARAMETERIZED, 1),
+            invocation(UNSHARDED_PARAMETERIZED, 2),
+            invocation(UNSHARDED_PARAMETERIZED, 3)),
+        started);
+    assertEquals(
+        Set.of(
+            invocation(SHARDED_PARAMETERIZED, 1),
+            invocation(SHARDED_PARAMETERIZED, 2),
+            invocation(SHARDED_PARAMETERIZED, 4),
+            invocation(SHARDED_PARAMETERIZED, 5),
+            invocation(SHARDED_PARAMETERIZED, 7),
+            invocation(SHARDED_REPEATED, 1),
+            invocation(SHARDED_REPEATED, 2),
+            invocation(SHARDED_REPEATED, 4),
+            invocation(SHARDED_REPEATED, 5)),
+        skipped);
+  }
+
+  private UniqueId invocation(UniqueId templateId, int invocation) {
+    return templateId.append("test-template-invocation", "#" + invocation);
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/InvocationShardingUnshardedTest.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/InvocationShardingUnshardedTest.java
@@ -1,0 +1,97 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.github.bazel_contrib.contrib_rules_jvm.junit5.sample.ShardingAnnotatedTests;
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.platform.engine.UniqueId;
+import org.junit.platform.engine.discovery.DiscoverySelectors;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.PostDiscoveryFilter;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestIdentifier;
+import org.junit.platform.launcher.core.LauncherConfig;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+
+/**
+ * Companion to {@link InvocationShardingTest} which runs without sharding: {@link
+ * ShardTemplateInvocations} must have no effect when test sharding is not enabled, so every
+ * invocation of every test template runs and nothing is skipped.
+ */
+public class InvocationShardingUnshardedTest {
+
+  private static final UniqueId ENGINE_ID = UniqueId.forEngine("junit-jupiter");
+  private static final UniqueId TEST_CLASS =
+      ENGINE_ID.append("class", ShardingAnnotatedTests.class.getName());
+  private static final UniqueId SHARDED_PARAMETERIZED =
+      TEST_CLASS.append("test-template", "testShardedParameterized(int)");
+  private static final UniqueId SHARDED_REPEATED =
+      TEST_CLASS.append("test-template", "testShardedRepeated()");
+  private static final UniqueId UNSHARDED_PARAMETERIZED =
+      TEST_CLASS.append("test-template", "testUnshardedParameterized(int)");
+
+  @Test
+  public void allInvocationsRunWhenShardingIsDisabled() {
+    assertNull(System.getenv("TEST_TOTAL_SHARDS"));
+
+    LauncherDiscoveryRequest request =
+        LauncherDiscoveryRequestBuilder.request()
+            .selectors(DiscoverySelectors.selectClass(ShardingAnnotatedTests.class))
+            .build();
+
+    Set<UniqueId> started = new HashSet<>();
+    Set<UniqueId> skipped = new HashSet<>();
+    PostDiscoveryFilter shardFilter = TestSharding.makeShardFilter();
+    LauncherConfig config =
+        LauncherConfig.builder()
+            .addTestExecutionListeners(
+                new TestExecutionListener() {
+                  @Override
+                  public void executionStarted(TestIdentifier testIdentifier) {
+                    started.add(testIdentifier.getUniqueIdObject());
+                  }
+
+                  @Override
+                  public void executionSkipped(TestIdentifier testIdentifier, String reason) {
+                    skipped.add(testIdentifier.getUniqueIdObject());
+                  }
+                })
+            .addPostDiscoveryFilters(shardFilter)
+            .build();
+
+    LauncherFactory.create(config).execute(request);
+
+    assertEquals(
+        Set.of(
+            ENGINE_ID,
+            TEST_CLASS,
+            SHARDED_PARAMETERIZED,
+            invocation(SHARDED_PARAMETERIZED, 1),
+            invocation(SHARDED_PARAMETERIZED, 2),
+            invocation(SHARDED_PARAMETERIZED, 3),
+            invocation(SHARDED_PARAMETERIZED, 4),
+            invocation(SHARDED_PARAMETERIZED, 5),
+            invocation(SHARDED_PARAMETERIZED, 6),
+            invocation(SHARDED_PARAMETERIZED, 7),
+            SHARDED_REPEATED,
+            invocation(SHARDED_REPEATED, 1),
+            invocation(SHARDED_REPEATED, 2),
+            invocation(SHARDED_REPEATED, 3),
+            invocation(SHARDED_REPEATED, 4),
+            invocation(SHARDED_REPEATED, 5),
+            UNSHARDED_PARAMETERIZED,
+            invocation(UNSHARDED_PARAMETERIZED, 1),
+            invocation(UNSHARDED_PARAMETERIZED, 2),
+            invocation(UNSHARDED_PARAMETERIZED, 3)),
+        started);
+    assertEquals(Set.of(), skipped);
+  }
+
+  private UniqueId invocation(UniqueId templateId, int invocation) {
+    return templateId.append("test-template-invocation", "#" + invocation);
+  }
+}

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample/BUILD.bazel
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample/BUILD.bazel
@@ -13,3 +13,18 @@ java_library(
         artifact("org.junit.jupiter:junit-jupiter-params", "contrib_rules_jvm_tests"),
     ] + junit5_deps("contrib_rules_jvm_tests"),
 )
+
+# Deliberately kept out of :sharding-test-tests: ShardingTest discovers the whole sample package,
+# so adding classes to that library would change its golden per-shard assertions.
+java_library(
+    name = "invocation-sharding-test-tests",
+    srcs = [
+        "ShardingAnnotatedTests.java",
+    ],
+    visibility = ["//java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5:__pkg__"],
+    deps = [
+        "//java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5",
+        artifact("org.junit.jupiter:junit-jupiter-api", "contrib_rules_jvm_tests"),
+        artifact("org.junit.jupiter:junit-jupiter-params", "contrib_rules_jvm_tests"),
+    ] + junit5_deps("contrib_rules_jvm_tests"),
+)

--- a/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample/ShardingAnnotatedTests.java
+++ b/java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/sample/ShardingAnnotatedTests.java
@@ -1,0 +1,21 @@
+package com.github.bazel_contrib.contrib_rules_jvm.junit5.sample;
+
+import com.github.bazel_contrib.contrib_rules_jvm.junit5.ShardTemplateInvocations;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class ShardingAnnotatedTests {
+  @ShardTemplateInvocations
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+  void testShardedParameterized(int value) {}
+
+  @ShardTemplateInvocations
+  @RepeatedTest(5)
+  void testShardedRepeated() {}
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, 1, 2})
+  void testUnshardedParameterized(int value) {}
+}


### PR DESCRIPTION
Fixes #279.

## Problem

The JUnit5 runner implements Bazel test sharding as a `PostDiscoveryFilter`, which assigns each test descriptor to a shard by hashing its unique ID. Post-discovery filters run before test templates (`@ParameterizedTest`, `@RepeatedTest`) have generated their invocations — the invocations simply do not exist at discovery time — so a template can only be filtered as a single unit, and all of its invocations land on the same shard.

This pins the full cost of a large parameterized test onto one shard. As a data point from a large monorepo: one sub-shard of an acceptance-test target consistently ran ~760s while its sibling shards ran ~90s, entirely because of this behaviour. The available workaround (manually splitting a parameterized method into several wrapper methods, each running a partition of the arguments) works but is pure boilerplate.

## Approach

Since invocation-level filtering cannot happen at discovery time, this PR splits the decision across discovery and execution, behind a new opt-in annotation:

- **`@ShardTemplateInvocations`** (`METHOD`/`TYPE`): opts a test template — or every template in a class — into invocation-level sharding. It is meta-annotated with `@ExtendWith(TemplateInvocationShardingCondition.class)`, so applying it registers the condition; no global extension registration is involved, and behaviour is unchanged for everyone who does not use the annotation.
- **Shard filter** (`TestSharding`): descriptors for annotated test templates (detected via `AnnotationSupport.findAnnotation` on the `MethodSource` method, its class, superclasses, and enclosing classes) are now included on *every* shard instead of being hash-assigned to one. Any reflective failure falls back to the existing single-unit behaviour.
- **`TemplateInvocationShardingCondition`** (`ExecutionCondition`): at execution time, enables each `test-template-invocation` on exactly one shard, assigning invocation `N` (1-based) round-robin to shard `(N - 1) % TEST_TOTAL_SHARDS`. Round-robin is deterministic and keeps per-shard invocation counts balanced. Containers pass through, and the condition is a no-op when sharding is not enabled. Invocations belonging to other shards show up as skipped in that shard's XML output.

Caveats, documented on the annotation and in the runner README:

- The set and order of invocations must be stable across shards (deterministic argument providers), otherwise invocations may run on multiple shards or none.
- `@TestFactory` is not supported: dynamic tests cannot be conditionally disabled, so the filter deliberately applies the include-on-every-shard behaviour only to `test-template` descriptors and factories continue to be sharded as a single unit (including a factory everywhere would duplicate its tests on every shard).

## Testing

- New `invocation-sharding-test` (`shard_count = 3`), mirroring the existing `sharding-test`: runs the JUnit Platform launcher in-process with the shard filter installed against a new sample class (kept in a separate `java_library` so the existing `sharding-test` golden assertions are untouched) containing an annotated `@ParameterizedTest` with 7 invocations, an annotated `@RepeatedTest(5)`, and a non-annotated `@ParameterizedTest`. Each shard asserts the exact set of started and skipped descriptors: annotated templates start on every shard with exactly the round-robin slice of invocations started and the rest skipped, while the non-annotated template retains the existing behaviour (all invocations on a single hash-assigned shard).
- New `invocation-sharding-unsharded-test`: runs the same sample class without sharding and asserts every invocation runs and nothing is skipped.
- The existing `sharding-test` golden per-shard sets pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)