### PR TITLE
Time-bound and cache the hostname lookup in TestSuiteXmlRenderer

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
@@ -11,11 +11,20 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Locale;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import org.junit.platform.launcher.TestPlan;
 
 class TestSuiteXmlRenderer {
+
+  // Resolved once and time-bounded: InetAddress.getLocalHost() consults the system resolver,
+  // and on a host with an unresponsive resolver (and a hostname absent from /etc/hosts) the
+  // native lookup can block indefinitely. This is called while rendering results of completed
+  // tests, so an unbounded lookup hangs the JVM after the tests have already passed. The
+  // hostname is cosmetic report metadata; it must never be able to hang the run.
+  private static final String HOSTNAME = resolveHostname();
 
   private final TestCaseXmlRenderer testRenderer;
 
@@ -84,10 +93,27 @@ class TestSuiteXmlRenderer {
   }
 
   private String getHostname() {
+    return HOSTNAME;
+  }
+
+  private static String resolveHostname() {
+    FutureTask<String> lookup = new FutureTask<>(() -> InetAddress.getLocalHost().getHostName());
+    Thread resolver = new Thread(lookup, "junit5-xml-hostname-resolver");
+    // A daemon thread so that a lookup which never returns cannot keep the JVM alive.
+    resolver.setDaemon(true);
+    resolver.start();
     try {
-      return InetAddress.getLocalHost().getHostName();
+      return lookup.get(5, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      return fallbackHostname();
     } catch (Exception e) {
-      return "localhost";
+      return fallbackHostname();
     }
+  }
+
+  private static String fallbackHostname() {
+    String envHostname = System.getenv("HOSTNAME");
+    return envHostname == null || envHostname.isEmpty() ? "localhost" : envHostname;
   }
 }


### PR DESCRIPTION
Fixes #473.

`TestSuiteXmlRenderer.getHostname()` called `InetAddress.getLocalHost()` on every suite render. That consults the system resolver, and on a host whose resolver is unresponsive (and whose hostname is absent from `/etc/hosts`) the native lookup blocks **indefinitely** — the existing `catch → "localhost"` never helps because the failure mode is a hang, not an exception. A test JVM whose tests had already passed could hang forever writing the XML report; and because the hang occurs while `BazelJUnitOutputListener.output()` holds its lock, the shutdown hook deadlocks on the same monitor, so `SIGTERM` can't produce a clean exit either. Full thread dump from a real occurrence (Linux CI, contrib_rules_jvm 0.33.0) is in #473.

This change:

- resolves the hostname **once per JVM** (static cache) instead of per suite render;
- performs the lookup on a **daemon thread bounded at 5 seconds** (`FutureTask.get`), so a never-returning native lookup can neither block the render nor keep the JVM alive at exit;
- falls back to the `HOSTNAME` environment variable, then `"localhost"`, keeping the attribute meaningful on machines where the env var is set but the resolver isn't answering.

Verified locally: `bazel build //java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5` and `bazel test //java/test/com/github/bazel_contrib/contrib_rules_jvm/junit5/...` — 92/92 pass, including the checkstyle/pmd/spotbugs targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)