### PR TITLE
[gazelle] Only suppress Kotlin stdlib deps for Kotlin rules

### DIFF
--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -242,6 +242,12 @@ func (jr *Resolver) populateAttr(c *config.Config, pc *javaconfig.Config, r *rul
 	}
 
 	for _, imp := range requiredPackageNames.SortedSlice() {
+		// rules_kotlin supplies the Kotlin standard library implicitly, but Java rules do
+		// not. Only suppress kotlin.* dependencies for targets that contain Kotlin sources.
+		if ruleHasKotlinSources(r) && kotlin.IsStdlib(imp) {
+			continue
+		}
+
 		var pkgClasses []string
 		for _, cls := range classesByPackage[imp] {
 			pkgClasses = append(pkgClasses, cls.BareOuterClassName())
@@ -494,9 +500,6 @@ func (jr *Resolver) resolveSinglePackageWithAmbiguity(c *config.Config, pc *java
 	}()
 
 	if java.IsStdlib(imp) {
-		return label.NoLabel, false
-	}
-	if kotlin.IsStdlib(imp) {
 		return label.NoLabel, false
 	}
 

--- a/java/gazelle/resolve_test.go
+++ b/java/gazelle/resolve_test.go
@@ -186,6 +186,28 @@ java_library(
     deps = ["@maven//:com_google_guava_guava"],
 )`,
 		},
+		"java-kotlin-stdlib": {
+			old: buildFile{
+				rel: "",
+				content: `load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "myproject",
+    srcs = ["App.java"],
+    _imported_packages = ["kotlin.random"],
+    _packages = ["com.example"],
+    visibility = ["//:__subpackages__"],
+)`,
+			},
+			want: `load("@rules_java//java:defs.bzl", "java_library")
+
+java_library(
+    name = "myproject",
+    srcs = ["App.java"],
+    visibility = ["//:__subpackages__"],
+    deps = ["@maven//:org_jetbrains_kotlin_kotlin_stdlib"],
+)`,
+		},
 		"kotlin": {
 			old: buildFile{
 				rel: "",
@@ -420,6 +442,7 @@ func NewTestMavenResolver() *TestMavenResolver {
 	return &TestMavenResolver{
 		data: map[types.PackageName]label.Label{
 			types.NewPackageName("com.google.common.primitives"): label.New("maven", "", "com_google_guava_guava"),
+			types.NewPackageName("kotlin.random"):                label.New("maven", "", "org_jetbrains_kotlin_kotlin_stdlib"),
 			types.NewPackageName("org.junit"):                    label.New("maven", "", "junit_junit"),
 		},
 	}


### PR DESCRIPTION
Java-only targets that import Kotlin APIs do not get rules_kotlin's implicit stdlib dependency, so Gazelle currently omits a needed dep. This moves the kotlin.* suppression to Kotlin-source rules while letting Java rules resolve the Kotlin stdlib normally.