### PR TITLE
[gazelle] Resolve test-suite helper classes in split packages

### DIFF
--- a/java/gazelle/BUILD.bazel
+++ b/java/gazelle/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "configure_test.go",
         "generate_test.go",
         "lang_test.go",
+        "resolve_split_test.go",
         "resolve_test.go",
     ],
     embed = [":gazelle"],

--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -360,6 +360,9 @@ func (jr *Resolver) populateAttr(c *config.Config, pc *javaconfig.Config, r *rul
 				if l == label.NoLabel {
 					l = jr.resolveSingleClass(c, pc, className, ix, from, isTestRule)
 				}
+				if l == label.NoLabel && isTestRule {
+					l = jr.resolveTestSuiteHelperClass(c, imp, className, ix, from)
+				}
 				if l != label.NoLabel {
 					labels.Add(simplifyLabel(c.RepoName, l, from))
 					resolvedAny = true

--- a/java/gazelle/resolve_split_test.go
+++ b/java/gazelle/resolve_split_test.go
@@ -1,0 +1,117 @@
+package gazelle
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/sorted_set"
+	"github.com/bazel-contrib/rules_jvm/java/gazelle/private/types"
+	"github.com/bazelbuild/bazel-gazelle/label"
+	"github.com/bazelbuild/bazel-gazelle/resolve"
+	"github.com/bazelbuild/bazel-gazelle/rule"
+)
+
+// TestSplitPackageTestSuiteHelperResolution covers a test helper whose package
+// has multiple production providers. Package resolution is ambiguous in that
+// case, so class-level resolution must still consider the helper library emitted
+// by java_test_suite.
+func TestSplitPackageTestSuiteHelperResolution(t *testing.T) {
+	c, langs, _ := testConfig(t)
+	mrslv, exts := InitTestResolversAndExtensions(langs)
+	ix := resolve.NewRuleIndex(mrslv.Resolver, exts...)
+	rc := testRemoteCache(nil)
+
+	var jLang *javaLang
+	for _, lang := range langs {
+		if jl, ok := lang.(*javaLang); ok {
+			jLang = jl
+			break
+		}
+	}
+	if jLang == nil {
+		t.Fatal("javaLang not found in test config")
+	}
+
+	javaPackage := types.NewPackageName("com.example.shared")
+	productionContent := `java_library(
+    name = "one",
+    _packages = ["com.example.shared"],
+)
+
+java_library(
+    name = "two",
+    _packages = ["com.example.shared"],
+)
+`
+	productionFile, err := rule.LoadData(filepath.Join("production", "BUILD.bazel"), "production", []byte(productionContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i, r := range productionFile.Rules {
+		setPackagesPrivateAttr(r)
+		providerLabel := label.New("", "production", r.Name())
+		jLang.classExportCache[providerLabel.String()] = classExportInfo{
+			classes:  []types.ClassName{types.NewClassName(javaPackage, []string{"One", "Two"}[i])},
+			testonly: false,
+		}
+		ix.AddRule(c, r, productionFile)
+	}
+
+	suiteContent := `java_test_suite(
+    name = "suite",
+)
+`
+	suiteFile, err := rule.LoadData(filepath.Join("helpers", "BUILD.bazel"), "helpers", []byte(suiteContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	suiteRule := suiteFile.Rules[0]
+	suiteRule.SetPrivateAttr(packagesKey, []types.ResolvableJavaPackage{
+		*types.NewResolvableJavaPackage(javaPackage, true, true),
+	})
+	helperLabel := label.New("", "helpers", "suite-test-lib")
+	jLang.classExportCache[helperLabel.String()] = classExportInfo{
+		classes:  []types.ClassName{types.NewClassName(javaPackage, "Helper")},
+		testonly: true,
+	}
+	ix.AddRule(c, suiteRule, suiteFile)
+	ix.Finish()
+
+	productionSpec := resolve.ImportSpec{Lang: languageName, Imp: types.NewResolvableJavaPackage(javaPackage, false, false).String()}
+	if got := len(ix.FindRulesByImportWithConfig(c, productionSpec, languageName)); got != 2 {
+		t.Fatalf("test precondition violated: got %d production providers, want 2", got)
+	}
+
+	importerContent := `java_test_suite(
+    name = "consumer",
+)
+`
+	importerFile, err := rule.LoadData("BUILD.bazel", "", []byte(importerContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	importerRule := importerFile.Rules[0]
+	resolveInput := types.ResolveInput{
+		PackageNames:         testPackageNames(),
+		ImportedPackageNames: testPackageNames(javaPackage),
+		ImportedClasses:      testClassNames(types.NewClassName(javaPackage, "Helper")),
+		ExportedPackageNames: testPackageNames(),
+		ExportedClassNames:   testClassNames(),
+		AnnotationProcessors: testClassNames(),
+	}
+
+	mrslv.Resolver(importerRule, "").Resolve(c, ix, rc, importerRule, resolveInput, label.New("", "", "consumer"))
+
+	got := importerRule.AttrStrings("deps")
+	if len(got) != 1 || got[0] != "//helpers:suite-test-lib" {
+		t.Errorf("deps mismatch: got %v, want [//helpers:suite-test-lib]", got)
+	}
+}
+
+func testPackageNames(values ...types.PackageName) *sorted_set.SortedSet[types.PackageName] {
+	return sorted_set.NewSortedSetFn(values, types.PackageNameLess)
+}
+
+func testClassNames(values ...types.ClassName) *sorted_set.SortedSet[types.ClassName] {
+	return sorted_set.NewSortedSetFn(values, types.ClassNameLess)
+}


### PR DESCRIPTION
This is stacked on #467; only the top commit is new, and it will be rebased once #467 merges.

When a test imports a java_test_suite helper class from a split package, package-level resolution is ambiguous and class-level resolution skipped the generated helper library.

Fall back to test-suite helper class resolution for test rules when ordinary class resolution cannot resolve the import.