### PR TITLE
[gazelle] Resolve nested classes through their outer class in the Maven index

### DIFF
--- a/java/gazelle/private/maven/resolver.go
+++ b/java/gazelle/private/maven/resolver.go
@@ -249,6 +249,12 @@ func (r *resolver) Resolve(pkg types.PackageName, excludedArtifacts map[string]s
 func (r *resolver) ResolveClass(className types.ClassName, excludedArtifacts map[string]struct{}, mavenRepositoryName string) (label.Label, error) {
 	artifact, found := r.classIndex[className.FullyQualifiedClassName()]
 	if !found {
+		// rules_jvm_external intentionally indexes only top-level classes. A named nested
+		// class is compiled into the same artifact as its outer class, so use the indexed
+		// outer class as its owner when the full source-level name has no entry.
+		artifact, found = r.classIndex[className.FullyQualifiedOuterClassName()]
+	}
+	if !found {
 		return label.NoLabel, nil
 	}
 

--- a/java/gazelle/private/maven/resolver_test.go
+++ b/java/gazelle/private/maven/resolver_test.go
@@ -77,6 +77,10 @@ func TestResolverClassifier(t *testing.T) {
 	// Tiebreak: a class listed in BOTH the plain and the test-fixtures jar
 	// resolves to the plain label
 	assertResolvesClass(t, r, none, "com.example.fixtures.SharedHelper", "@maven//:com_example_lib")
+	// rules_jvm_external omits nested classes from its index. Resolve a nested
+	// source-level name through its indexed outer class instead.
+	assertResolvesClass(t, r, none, "com.example.fixtures.Widget.Nested",
+		"@maven//:com_example_lib")
 }
 
 func assertResolvesClass(t *testing.T, r Resolver, excludeArtifacts map[string]struct{}, className, wantLabelStr string) {


### PR DESCRIPTION
rules_jvm_external indexes only top-level classes, so named nested-class imports miss Maven dependency resolution.

This resolves a missed nested-class lookup through the indexed outer class, which lives in the same artifact.