### PR TITLE
Fix ~5s class-init deadlock in TestSuiteXmlRenderer hostname resolution

### DIFF
--- a/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
+++ b/java/src/com/github/bazel_contrib/contrib_rules_jvm/junit5/TestSuiteXmlRenderer.java
@@ -3,7 +3,6 @@ package com.github.bazel_contrib.contrib_rules_jvm.junit5;
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.escapeIllegalCharacters;
 import static com.github.bazel_contrib.contrib_rules_jvm.junit5.SafeXml.writeTextElement;
 
-import java.net.InetAddress;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
@@ -11,20 +10,20 @@ import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Collection;
 import java.util.Locale;
-import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 import org.junit.platform.launcher.TestPlan;
 
 class TestSuiteXmlRenderer {
 
-  // Resolved once and time-bounded: InetAddress.getLocalHost() consults the system resolver,
-  // and on a host with an unresponsive resolver (and a hostname absent from /etc/hosts) the
-  // native lookup can block indefinitely. This is called while rendering results of completed
-  // tests, so an unbounded lookup hangs the JVM after the tests have already passed. The
-  // hostname is cosmetic report metadata; it must never be able to hang the run.
-  private static final String HOSTNAME = resolveHostname();
+  // InetAddress.getLocalHost() consults the system resolver, and on a host with an unresponsive
+  // resolver (and a hostname absent from /etc/hosts) the native lookup can block indefinitely,
+  // hanging the JVM after the tests have already passed. Time-bounding the lookup from this
+  // static initializer doesn't work either: a lookup thread started inside <clinit> blocks on
+  // this class's initialization lock before it can run the lookup (JLS 12.4.2), so a bounded
+  // wait always runs to its full timeout. The hostname is cosmetic report metadata, so skip
+  // the resolver entirely.
+  private static final String HOSTNAME = fallbackHostname();
 
   private final TestCaseXmlRenderer testRenderer;
 
@@ -94,22 +93,6 @@ class TestSuiteXmlRenderer {
 
   private String getHostname() {
     return HOSTNAME;
-  }
-
-  private static String resolveHostname() {
-    FutureTask<String> lookup = new FutureTask<>(() -> InetAddress.getLocalHost().getHostName());
-    Thread resolver = new Thread(lookup, "junit5-xml-hostname-resolver");
-    // A daemon thread so that a lookup which never returns cannot keep the JVM alive.
-    resolver.setDaemon(true);
-    resolver.start();
-    try {
-      return lookup.get(5, TimeUnit.SECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      return fallbackHostname();
-    } catch (Exception e) {
-      return fallbackHostname();
-    }
   }
 
   private static String fallbackHostname() {


### PR DESCRIPTION
## Problem

`TestSuiteXmlRenderer` resolves the local hostname in a static initializer:

```java
private static final String HOSTNAME = resolveHostname();

private static String resolveHostname() {
  FutureTask<String> lookup = new FutureTask<>(() -> InetAddress.getLocalHost().getHostName());
  Thread resolver = new Thread(lookup, "junit5-xml-hostname-resolver");
  resolver.setDaemon(true);
  resolver.start();
  try {
    return lookup.get(5, TimeUnit.SECONDS);
  } ...
}
```

This is a class-initialization deadlock: the main thread holds the `TestSuiteXmlRenderer` class initialization lock while it waits on `lookup.get(5, SECONDS)`. The lambda body compiles to a synthetic static method of `TestSuiteXmlRenderer`, so the spawned resolver thread must acquire that same initialization lock before it can execute the lookup (JLS §12.4.2 — the classic "thread started inside `<clinit>`" deadlock). As a result `lookup.get` **always** waits the full 5 seconds and then falls back to `fallbackHostname()`, regardless of how fast `InetAddress.getLocalHost()` actually is.

Because `TestSuiteXmlRenderer` is only loaded when the XML report is written after the last test, the pause appears at the very end of every junit5 test run — and the DNS-resolved hostname never makes it into the report anyway.

## Repro

```java
long start = System.currentTimeMillis();
Class.forName("com.github.bazel_contrib.contrib_rules_jvm.junit5.TestSuiteXmlRenderer");
System.out.println("ms=" + (System.currentTimeMillis() - start));
```

Consistently ~5000 ms.

## Fix

The `<testsuite hostname="...">` attribute is cosmetic report metadata (per the existing comment). Initialize `HOSTNAME` from `fallbackHostname()` (`$HOSTNAME` env var, else `"localhost"`) and remove the DNS/threading lookup entirely, along with its now-unused imports. This eliminates the class-init deadlock and the 5s pause while keeping the original goal intact: the hostname lookup can never hang or delay the run.

If keeping the DNS-resolved hostname is preferred, an alternative is to move the time-bounded lookup out of `<clinit>` (e.g. into a separate holder class or a lazy supplier) so the timeout mechanism actually works — happy to rework the PR that way instead.

## Environment

- contrib_rules_jvm v0.34.0 (bug present on `main` as well)
- OpenJDK Corretto 26.0.1
- Bazel 9.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)
