### PR TITLE
[gazelle] Reconcile managed source-set resources

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -112,7 +112,7 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 		srcFilenamesRelativeToPackage = filterStrSlice(args.RegularFiles, func(f string) bool { return filepath.Ext(f) == ".java" })
 	}
 
-	isResourcesRoot := strings.HasSuffix(args.Rel, "/resources")
+	isResourcesRoot := cfg.SourcesetRoot() != "" && args.Rel == path.Join(cfg.SourcesetRoot(), "resources")
 	isResourcesSubdir := strings.Contains(args.Rel, "/resources/") && !isResourcesRoot
 	granularity := cfg.ModuleGranularity()
 	// "module" emits one coarse library for the whole subtree; "scc" emits the minimal set
@@ -390,6 +390,11 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 				resourceLib.SetAttr("visibility", []string{"//:__subpackages__"})
 				res.Gen = append(res.Gen, resourceLib)
 				res.Imports = append(res.Imports, types.ResolveInput{})
+			}
+		} else {
+			res.Empty = append(res.Empty, rule.NewRule("pkg_files", "resources"))
+			if !aggregateAtRoot {
+				res.Empty = append(res.Empty, rule.NewRule(javaLibraryKind, "resources_lib"))
 			}
 		}
 	} else if productionJavaFiles.Len() > 0 {

--- a/java/gazelle/lang.go
+++ b/java/gazelle/lang.go
@@ -171,6 +171,11 @@ var kotlinLibraryKind = rule.KindInfo{
 	},
 }
 
+var pkgFilesKind = rule.KindInfo{
+	NonEmptyAttrs:  map[string]bool{"srcs": true},
+	MergeableAttrs: map[string]bool{"srcs": true},
+}
+
 func (l javaLang) Kinds() map[string]rule.KindInfo {
 	kinds := map[string]rule.KindInfo{
 		"java_binary":        kindWithRuntimeDeps,
@@ -182,6 +187,7 @@ func (l javaLang) Kinds() map[string]rule.KindInfo {
 		"java_proto_library": kindWithoutRuntimeDeps,
 		"java_grpc_library":  kindWithoutRuntimeDeps,
 		"kt_jvm_library":     kotlinLibraryKind,
+		"pkg_files":          pkgFilesKind,
 	}
 
 	c := l.Configurer.(*Configurer)

--- a/java/gazelle/testdata/resources_custom_sourceset/src/empty/resources/BUILD.in
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/empty/resources/BUILD.in
@@ -1,12 +1,11 @@
+# gazelle:java_generate_resources true
+
 load("@rules_java//java:defs.bzl", "java_library")
 load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 pkg_files(
     name = "resources",
-    srcs = [
-        "config.xml",
-        "obsolete.properties",
-    ],
+    srcs = ["removed.txt"],
     strip_prefix = "",
 )
 

--- a/java/gazelle/testdata/resources_custom_sourceset/src/empty/resources/BUILD.out
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/empty/resources/BUILD.out
@@ -1,0 +1,1 @@
+# gazelle:java_generate_resources true

--- a/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/BUILD.in
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/BUILD.in
@@ -3,10 +3,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 pkg_files(
     name = "resources",
-    srcs = [
-        "config.xml",
-        "obsolete.properties",
-    ],
+    srcs = ["tracked.txt"],
     strip_prefix = "",
 )
 

--- a/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/BUILD.out
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/BUILD.out
@@ -3,10 +3,7 @@ load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 pkg_files(
     name = "resources",
-    srcs = [
-        "config.xml",
-        "obsolete.properties",
-    ],
+    srcs = ["tracked.txt"],
     strip_prefix = "",
 )
 

--- a/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/tracked.txt
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/tracked.txt
@@ -1,0 +1,1 @@
+tracked

--- a/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/unlisted.txt
+++ b/java/gazelle/testdata/resources_custom_sourceset/src/sample/java/com/example/resources/unlisted.txt
@@ -1,0 +1,1 @@
+unlisted


### PR DESCRIPTION
Gazelle does not reconcile generated resource `pkg_files` after source files change. Update only exact source-set roots, reconcile their files and delete them when empty while preserving nested non-owned rules. Only generated output within resource source-set roots changes. 

Generated with Codex.