### PR TITLE
[gazelle] Correct SCC target regeneration

### DIFF
--- a/java/gazelle/generate.go
+++ b/java/gazelle/generate.go
@@ -427,6 +427,7 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 			// library per package. Collapse only the packages that must share a module
 			// (import cycles + internal coupling) into the minimal set of targets;
 			// everything else stays its own per-package library.
+			markExistingSCCLibrariesForDeletion(args.File, &res)
 			l.emitModuleProductionLibraries(args, cfg, likelyLocalClassNames, resourcesDirectRef, resourcesRuntimeDep, &res, log)
 		} else {
 			// "module" (one coarse library for the whole subtree) and "package" (this
@@ -579,6 +580,22 @@ func (l javaLang) GenerateRules(args language.GenerateArgs) language.GenerateRes
 	}
 
 	return res
+}
+
+func markExistingSCCLibrariesForDeletion(file *rule.File, res *language.GenerateResult) {
+	if file == nil {
+		return
+	}
+
+	for _, existing := range file.Rules {
+		if existing.Kind() != "java_library" && existing.Kind() != "kt_jvm_library" {
+			continue
+		}
+		if len(existing.AttrStrings("srcs")) == 0 {
+			continue
+		}
+		res.Empty = append(res.Empty, rule.NewRule(existing.Kind(), existing.Name()))
+	}
 }
 
 // emitModuleProductionLibraries emits one production library per SCC group of the

--- a/java/gazelle/resolve.go
+++ b/java/gazelle/resolve.go
@@ -388,16 +388,18 @@ func (jr *Resolver) populateAttr(c *config.Config, pc *javaconfig.Config, r *rul
 
 	// A class whose package this rule owns is normally assumed to be provided by the rule
 	// itself, so that package is filtered out of requiredPackageNames and the loop above
-	// never visits it. But an external gazelle plugin (e.g. notification-builder's Campaigns)
-	// can provide a class in a package the rule otherwise owns -- a split package. The
-	// generate step keeps such a class in importedClasses precisely because the rule does
-	// not declare it, so consult registered CrossResolvers for its real provider.
+	// never visits it. A split package may instead provide that class from another rule.
+	// The generate step keeps such a class in importedClasses precisely because this rule
+	// does not declare it, so resolve it separately.
 	if importedClasses != nil && ownPackageNames != nil {
 		for _, className := range importedClasses.SortedSlice() {
 			if !ownPackageNames.Contains(className.PackageName()) {
 				continue
 			}
-			if l := jr.resolveClassFromCrossResolver(c, pc, className, ix, from); l != label.NoLabel {
+			if jr.ruleDeclaresClass(from, className) {
+				continue
+			}
+			if l := jr.resolveSingleClass(c, pc, className, ix, from, isTestRule); l != label.NoLabel {
 				labels.Add(l)
 			}
 		}

--- a/java/gazelle/resolve_split_test.go
+++ b/java/gazelle/resolve_split_test.go
@@ -108,6 +108,64 @@ java_library(
 	}
 }
 
+// TestInRepoClassLevelSplitPackageWithinOwnedPackage covers an SCC group that
+// references a class supplied by another in-repository target in a Java package
+// the group itself owns. The retained class must resolve through the class index.
+func TestInRepoClassLevelSplitPackageWithinOwnedPackage(t *testing.T) {
+	c, langs, _ := testConfig(t)
+	mrslv, exts := InitTestResolversAndExtensions(langs)
+	ix := resolve.NewRuleIndex(mrslv.Resolver, exts...)
+	rc := testRemoteCache(nil)
+
+	var jLang *javaLang
+	for _, lang := range langs {
+		if jl, ok := lang.(*javaLang); ok {
+			jLang = jl
+			break
+		}
+	}
+	if jLang == nil {
+		t.Fatal("javaLang not found in test config")
+	}
+
+	javaPackage := types.NewPackageName("com.example.foo")
+	providerContent := `java_library(
+    name = "foo",
+    _packages = ["com.example.foo"],
+)
+`
+	providerFile, err := rule.LoadData(filepath.Join("foo", "BUILD.bazel"), "foo", []byte(providerContent))
+	if err != nil {
+		t.Fatal(err)
+	}
+	providerRule := providerFile.Rules[0]
+	setPackagesPrivateAttr(providerRule)
+	providerLabel := label.New("", "foo", "foo")
+	jLang.classExportCache[providerLabel.String()] = classExportInfo{
+		classes:  []types.ClassName{types.NewClassName(javaPackage, "HandWritten")},
+		testonly: false,
+	}
+	ix.AddRule(c, providerRule, providerFile)
+	ix.Finish()
+
+	importerRule := rule.NewRule("java_library", "app")
+	resolveInput := types.ResolveInput{
+		PackageNames:         testPackageNames(javaPackage),
+		ImportedPackageNames: testPackageNames(),
+		ImportedClasses:      testClassNames(types.NewClassName(javaPackage, "HandWritten")),
+		ExportedPackageNames: testPackageNames(),
+		ExportedClassNames:   testClassNames(),
+		AnnotationProcessors: testClassNames(),
+	}
+
+	mrslv.Resolver(importerRule, "").Resolve(c, ix, rc, importerRule, resolveInput, label.New("", "", "app"))
+
+	got := importerRule.AttrStrings("deps")
+	if len(got) != 1 || got[0] != "//foo" {
+		t.Errorf("deps mismatch: got %v, want [//foo]", got)
+	}
+}
+
 func testPackageNames(values ...types.PackageName) *sorted_set.SortedSet[types.PackageName] {
 	return sorted_set.NewSortedSetFn(values, types.PackageNameLess)
 }

--- a/java/gazelle/testdata/java_module_scc/src/main/java/com/example/BUILD.in
+++ b/java/gazelle/testdata/java_module_scc/src/main/java/com/example/BUILD.in
@@ -1,2 +1,15 @@
 # gazelle:java_module_granularity scc
 # gazelle:jvm_kotlin_enabled false
+
+java_library(
+    name = "removed",
+    srcs = ["removed/Removed.java"],
+    deps = ["//removed"],
+)
+
+# keep
+java_library(
+    name = "custom",
+    srcs = ["solo/Solo.java"],
+    visibility = ["//visibility:private"],
+)

--- a/java/gazelle/testdata/java_module_scc/src/main/java/com/example/BUILD.out
+++ b/java/gazelle/testdata/java_module_scc/src/main/java/com/example/BUILD.out
@@ -3,6 +3,13 @@ load("@rules_java//java:defs.bzl", "java_library")
 # gazelle:java_module_granularity scc
 # gazelle:jvm_kotlin_enabled false
 
+# keep
+java_library(
+    name = "custom",
+    srcs = ["solo/Solo.java"],
+    visibility = ["//visibility:private"],
+)
+
 java_library(
     name = "a",
     srcs = [


### PR DESCRIPTION
SCC regeneration could leave stale generated libraries behind and miss in-repository split-package providers. This replaces generated SCC libraries before rebuilding them, resolves owned classes through the class index, and preserves user targets annotated with `# keep`.

Generated with Codex